### PR TITLE
refactor: customer sign-in flow with email verification and join page

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -48,7 +48,8 @@
       "Bash(git reset:*)",
       "Bash(node -e:*)",
       "Bash(sqlite3:*)",
-      "Bash(wc:*)"
+      "Bash(wc:*)",
+      "Bash(git push:*)"
     ]
   }
 }

--- a/apps/web/app/api/dashboard/settings/join-code/route.ts
+++ b/apps/web/app/api/dashboard/settings/join-code/route.ts
@@ -1,0 +1,97 @@
+// apps/web/app/api/dashboard/settings/join-code/route.ts
+
+import { NextResponse } from 'next/server';
+import { createServerSupabaseClient, createServiceClient } from '@/lib/supabase-server';
+import crypto from 'crypto';
+
+// ============================================
+// HELPER: Get Business ID for Owner
+// ============================================
+
+async function getOwnerBusinessId(userId: string): Promise<string | null> {
+  const supabase = createServiceClient();
+
+  const { data: business } = await supabase
+    .from('businesses')
+    .select('id')
+    .eq('owner_id', userId)
+    .maybeSingle();
+
+  return business?.id || null;
+}
+
+// ============================================
+// GET: Return current join_code
+// ============================================
+
+export async function GET() {
+  try {
+    const serverSupabase = await createServerSupabaseClient();
+    const { data: { user }, error: authError } = await serverSupabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const businessId = await getOwnerBusinessId(user.id);
+    if (!businessId) {
+      return NextResponse.json({ error: 'Business not found' }, { status: 404 });
+    }
+
+    const supabase = createServiceClient();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data, error } = await (supabase as any)
+      .from('businesses')
+      .select('join_code')
+      .eq('id', businessId)
+      .single();
+
+    if (error || !data) {
+      return NextResponse.json({ error: 'Failed to fetch join code' }, { status: 500 });
+    }
+
+    return NextResponse.json({ joinCode: data.join_code });
+  } catch (error) {
+    console.error('Get join code error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+// ============================================
+// POST: Regenerate join_code
+// ============================================
+
+export async function POST() {
+  try {
+    const serverSupabase = await createServerSupabaseClient();
+    const { data: { user }, error: authError } = await serverSupabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const businessId = await getOwnerBusinessId(user.id);
+    if (!businessId) {
+      return NextResponse.json({ error: 'Business not found' }, { status: 404 });
+    }
+
+    const newCode = crypto.randomBytes(4).toString('hex').toUpperCase();
+
+    const supabase = createServiceClient();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { error } = await (supabase as any)
+      .from('businesses')
+      .update({ join_code: newCode })
+      .eq('id', businessId);
+
+    if (error) {
+      console.error('Regenerate join code error:', error);
+      return NextResponse.json({ error: 'Failed to regenerate join code' }, { status: 500 });
+    }
+
+    return NextResponse.json({ joinCode: newCode });
+  } catch (error) {
+    console.error('Regenerate join code error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/apps/web/app/api/public/join/[code]/signup/route.ts
+++ b/apps/web/app/api/public/join/[code]/signup/route.ts
@@ -1,0 +1,181 @@
+// apps/web/app/api/public/join/[code]/signup/route.ts
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getBusinessByJoinCode } from '@/lib/services/public-business.service';
+import { createSelfSignupCustomer } from '@/lib/services/public-business.service';
+import { hasVerifiedCode } from '@/lib/services/verification.service';
+import { createServiceClient } from '@/lib/supabase-server';
+import type { Json } from '../../../../../../../../packages/shared/types/database';
+
+// ============================================
+// VALIDATION
+// ============================================
+
+const JoinSignupSchema = z.object({
+  fullName: z
+    .string()
+    .min(2, 'Name must be at least 2 characters')
+    .max(100, 'Name is too long'),
+  phone: z
+    .string()
+    .length(11, 'Phone number must be exactly 11 digits')
+    .regex(/^\d+$/, 'Phone number must contain only digits'),
+  email: z.string().email('Invalid email address'),
+});
+
+// ============================================
+// POST: Create verified customer
+// ============================================
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ code: string }> },
+) {
+  const startTime = Date.now();
+  const ipAddress =
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    request.headers.get('x-real-ip') ||
+    'unknown';
+
+  try {
+    const { code: joinCode } = await params;
+
+    // 1. Validate join code
+    const business = await getBusinessByJoinCode(joinCode);
+    if (!business) {
+      return NextResponse.json(
+        { error: 'Invalid join code' },
+        { status: 404 },
+      );
+    }
+
+    // 2. Parse and validate input
+    const body = await request.json();
+    const validation = JoinSignupSchema.safeParse(body);
+
+    if (!validation.success) {
+      return NextResponse.json(
+        {
+          error: 'Validation failed',
+          details: validation.error.flatten().fieldErrors,
+        },
+        { status: 400 },
+      );
+    }
+
+    const { fullName, phone, email } = validation.data;
+
+    // 3. Require email verification
+    const verified = await hasVerifiedCode(email, business.id);
+    if (!verified) {
+      return NextResponse.json(
+        { error: 'Email not verified. Please complete verification first.' },
+        { status: 403 },
+      );
+    }
+
+    // 4. Rate limit by IP
+    const serviceClient = createServiceClient();
+    const { data: rateLimitOk } = await serviceClient.rpc('check_rate_limit', {
+      p_identifier: ipAddress,
+      p_identifier_type: 'ip_address',
+      p_action: 'join_signup',
+      p_max_requests: 5,
+      p_window_seconds: 3600,
+    });
+
+    if (rateLimitOk === false) {
+      return NextResponse.json(
+        { error: 'Too many signup attempts. Please try again later.' },
+        { status: 429 },
+      );
+    }
+
+    // 5. Create or find customer (reuse existing logic)
+    const result = await createSelfSignupCustomer(
+      business.id,
+      fullName,
+      phone,
+      email,
+    );
+
+    // 6. Mark customer as verified (columns added via migration, not yet in generated types)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (serviceClient as any)
+      .from('customers')
+      .update({
+        is_verified: true,
+        verified_at: new Date().toISOString(),
+        verification_method: 'email_otp',
+      })
+      .eq('id', result.customerId);
+
+    // 7. Fetch customer data for response
+    let tier = 'bronze';
+    let totalPoints = 0;
+    let storedName = fullName;
+
+    const { data: customerData } = await serviceClient
+      .from('customers')
+      .select('tier, total_points, full_name')
+      .eq('id', result.customerId)
+      .single();
+
+    if (customerData) {
+      tier = customerData.tier || 'bronze';
+      totalPoints = customerData.total_points || 0;
+      storedName = customerData.full_name || fullName;
+    }
+
+    // 8. Name mismatch check for existing customers
+    if (!result.isNewCustomer) {
+      const normalizedInput = fullName.trim().toLowerCase();
+      const normalizedStored = storedName.trim().toLowerCase();
+
+      if (normalizedInput !== normalizedStored) {
+        return NextResponse.json(
+          {
+            error:
+              'This phone number is already registered under a different name.',
+          },
+          { status: 409 },
+        );
+      }
+    }
+
+    // 9. Audit log
+    await serviceClient.from('audit_logs').insert({
+      event_type: result.isNewCustomer
+        ? 'customer_verified_signup'
+        : 'customer_verified_signup_existing',
+      severity: 'info',
+      business_id: business.id,
+      user_id: null,
+      details: {
+        customerId: result.customerId,
+        isNewCustomer: result.isNewCustomer,
+        verificationMethod: 'email_otp',
+        processingTimeMs: Date.now() - startTime,
+        ipAddress,
+      } as Json,
+    });
+
+    return NextResponse.json({
+      success: true,
+      data: {
+        isNewCustomer: result.isNewCustomer,
+        customerName: result.isNewCustomer ? fullName : storedName,
+        qrCodeUrl: result.qrCodeUrl,
+        tier,
+        totalPoints,
+      },
+    });
+  } catch (error) {
+    console.error('Join signup error:', error);
+    return NextResponse.json(
+      { error: 'Something went wrong. Please try again.' },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/app/api/public/verify/check/route.ts
+++ b/apps/web/app/api/public/verify/check/route.ts
@@ -1,0 +1,72 @@
+// apps/web/app/api/public/verify/check/route.ts
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getBusinessByJoinCode } from '@/lib/services/public-business.service';
+import { verifyCode } from '@/lib/services/verification.service';
+
+// ============================================
+// VALIDATION
+// ============================================
+
+const CheckVerifySchema = z.object({
+  code: z
+    .string()
+    .length(6, 'Code must be 6 digits')
+    .regex(/^\d+$/, 'Code must contain only digits'),
+  email: z.string().email('Invalid email address'),
+  joinCode: z.string().min(1, 'Join code is required'),
+});
+
+// ============================================
+// POST: Verify OTP code
+// ============================================
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const validation = CheckVerifySchema.safeParse(body);
+
+    if (!validation.success) {
+      return NextResponse.json(
+        {
+          error: 'Validation failed',
+          details: validation.error.flatten().fieldErrors,
+        },
+        { status: 400 },
+      );
+    }
+
+    const { code, email, joinCode } = validation.data;
+
+    // Validate join code
+    const business = await getBusinessByJoinCode(joinCode);
+    if (!business) {
+      return NextResponse.json(
+        { error: 'Invalid join code' },
+        { status: 404 },
+      );
+    }
+
+    // Verify the code
+    const result = await verifyCode(code, email, business.id);
+
+    if (!result.success) {
+      return NextResponse.json(
+        { error: result.error || 'Invalid verification code' },
+        { status: 400 },
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      verificationId: result.verificationId,
+    });
+  } catch (error) {
+    console.error('Check verification error:', error);
+    return NextResponse.json(
+      { error: 'Something went wrong. Please try again.' },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/app/api/public/verify/send/route.ts
+++ b/apps/web/app/api/public/verify/send/route.ts
@@ -1,0 +1,70 @@
+// apps/web/app/api/public/verify/send/route.ts
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { getBusinessByJoinCode } from '@/lib/services/public-business.service';
+import { sendEmailVerification } from '@/lib/services/verification.service';
+
+// ============================================
+// VALIDATION
+// ============================================
+
+const SendVerifySchema = z.object({
+  email: z.string().email('Invalid email address'),
+  joinCode: z.string().min(1, 'Join code is required'),
+});
+
+// ============================================
+// POST: Send verification code
+// ============================================
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const validation = SendVerifySchema.safeParse(body);
+
+    if (!validation.success) {
+      return NextResponse.json(
+        {
+          error: 'Validation failed',
+          details: validation.error.flatten().fieldErrors,
+        },
+        { status: 400 },
+      );
+    }
+
+    const { email, joinCode } = validation.data;
+
+    // Validate join code matches a real business
+    const business = await getBusinessByJoinCode(joinCode);
+    if (!business) {
+      return NextResponse.json(
+        { error: 'Invalid join code' },
+        { status: 404 },
+      );
+    }
+
+    // Send verification email
+    const result = await sendEmailVerification(
+      email,
+      business.id,
+      business.name,
+      'signup',
+    );
+
+    if (!result.success) {
+      return NextResponse.json(
+        { error: result.error || 'Failed to send verification code' },
+        { status: 429 },
+      );
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Send verification error:', error);
+    return NextResponse.json(
+      { error: 'Something went wrong. Please try again.' },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/app/api/staff/customer/route.ts
+++ b/apps/web/app/api/staff/customer/route.ts
@@ -5,13 +5,7 @@ import {
   createServiceClient,
   createServerSupabaseClient,
 } from '@/lib/supabase-server';
-import {
-  generateQRToken,
-  generateQRCodeUrl,
-  generateCardToken,
-  generateQRCodeDataUrl,
-} from '@/lib/qr-code';
-import { sendWelcomeEmail } from '@/lib/email';
+import { sendCustomerInviteEmail } from '@/lib/email';
 import { z } from 'zod';
 import type { Json } from '../../../../../../packages/shared/types/database';
 
@@ -19,29 +13,13 @@ import type { Json } from '../../../../../../packages/shared/types/database';
 // VALIDATION SCHEMA
 // ============================================
 
-const AddCustomerSchema = z.object({
-  fullName: z
-    .string()
-    .min(2, 'Name must be at least 2 characters')
-    .max(100, 'Name too long')
-    .regex(/^[a-zA-Z\s\-'.]+$/, 'Name contains invalid characters'),
+const InviteCustomerSchema = z.object({
   email: z
     .string()
     .email('Invalid email address')
     .max(255, 'Email too long')
     .transform((e) => e.toLowerCase().trim()),
-  phone: z
-    .string()
-    .regex(/^\d{11}$/, 'Phone number must be exactly 11 digits'),
-  age: z
-    .number()
-    .int()
-    .min(13, 'Must be at least 13 years old')
-    .max(120, 'Invalid age')
-    .optional(),
 });
-
-type AddCustomerInput = z.infer<typeof AddCustomerSchema>;
 
 // ============================================
 // RATE LIMIT CONSTANTS
@@ -49,19 +27,34 @@ type AddCustomerInput = z.infer<typeof AddCustomerSchema>;
 
 const RATE_LIMIT = {
   maxRequests: 100,
-  windowSeconds: 3600, // 1 hour
+  windowSeconds: 3600,
 };
 
 // ============================================
 // HELPER FUNCTIONS
 // ============================================
 
+interface StaffBusiness {
+  id: string;
+  name: string;
+  slug: string;
+  logo_url: string | null;
+  join_code: string | null;
+}
+
+interface StaffInfo {
+  staffId: string;
+  staffName: string;
+  role: string;
+  business: StaffBusiness | null;
+}
+
 async function verifyStaffAndGetBusiness(
   supabase: ReturnType<typeof createServiceClient>,
   userId: string,
-) {
+): Promise<StaffInfo | null> {
   // Check if user is staff
-  const { data: staffRecord, error: staffError } = await supabase
+  const { data: staffRecord } = await supabase
     .from('staff')
     .select('id, business_id, role, name, is_active')
     .eq('user_id', userId)
@@ -69,9 +62,11 @@ async function verifyStaffAndGetBusiness(
     .maybeSingle();
 
   if (staffRecord) {
-    const { data: business } = await supabase
+    // join_code column not in generated types yet (migration pending)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data: business } = await (supabase as any)
       .from('businesses')
-      .select('id, name, slug, logo_url, address, city')
+      .select('id, name, slug, logo_url, join_code')
       .eq('id', staffRecord.business_id)
       .single();
 
@@ -79,14 +74,15 @@ async function verifyStaffAndGetBusiness(
       staffId: staffRecord.id,
       staffName: staffRecord.name,
       role: staffRecord.role,
-      business,
+      business: business as StaffBusiness | null,
     };
   }
 
   // Check if user is business owner
-  const { data: business } = await supabase
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data: business } = await (supabase as any)
     .from('businesses')
-    .select('id, name, slug, logo_url, address, city')
+    .select('id, name, slug, logo_url, join_code')
     .eq('owner_id', userId)
     .maybeSingle();
 
@@ -95,7 +91,7 @@ async function verifyStaffAndGetBusiness(
       staffId: userId,
       staffName: 'Owner',
       role: 'owner',
-      business,
+      business: business as StaffBusiness,
     };
   }
 
@@ -109,7 +105,7 @@ async function checkRateLimit(
   const { data } = await supabase.rpc('check_rate_limit', {
     p_identifier: staffId,
     p_identifier_type: 'user_id',
-    p_action: 'add_customer',
+    p_action: 'invite_customer',
     p_max_requests: RATE_LIMIT.maxRequests,
     p_window_seconds: RATE_LIMIT.windowSeconds,
   });
@@ -136,14 +132,13 @@ async function logAuditEvent(
 }
 
 // ============================================
-// POST: Add Customer
+// POST: Invite Customer
 // ============================================
 
 export async function POST(request: NextRequest) {
   const startTime = Date.now();
   const ipAddress =
     request.headers.get('x-forwarded-for')?.split(',')[0] || 'unknown';
-  const userAgent = request.headers.get('user-agent') || 'unknown';
 
   try {
     // 1. Authenticate user
@@ -171,18 +166,6 @@ export async function POST(request: NextRequest) {
     // 3. Check rate limit
     const withinLimit = await checkRateLimit(serviceClient, staffInfo.staffId);
     if (!withinLimit) {
-      await logAuditEvent(serviceClient, {
-        userId: user.id,
-        action: 'add_customer_rate_limited',
-        businessId: staffInfo.business.id,
-        details: {
-          staffId: staffInfo.staffId,
-          reason: 'rate_limit_exceeded',
-          ipAddress,
-          userAgent,
-        },
-      });
-
       return NextResponse.json(
         { error: 'Too many requests. Please try again later.' },
         { status: 429 },
@@ -191,7 +174,7 @@ export async function POST(request: NextRequest) {
 
     // 4. Parse and validate input
     const body = await request.json();
-    const validation = AddCustomerSchema.safeParse(body);
+    const validation = InviteCustomerSchema.safeParse(body);
 
     if (!validation.success) {
       return NextResponse.json(
@@ -203,160 +186,74 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const input: AddCustomerInput = validation.data;
+    const { email } = validation.data;
 
-    // 5. Check if customer exists or create new
-    let customerId: string;
-    let isNewCustomer: boolean;
-    let qrCodeUrl: string;
-    let cardToken: string;
-
-    const { data: existingCustomer } = await serviceClient
+    // 5. Check if customer already exists for this business
+    const { data: existingByEmail } = await serviceClient
       .from('customers')
-      .select('id, qr_code_url, card_token, full_name, email')
-      .eq('email', input.email)
+      .select('id')
+      .eq('email', email)
+      .eq('created_by_business_id', staffInfo.business.id)
       .maybeSingle();
 
-    if (existingCustomer) {
-      // Customer exists - use existing QR code
-      customerId = existingCustomer.id;
-      qrCodeUrl = existingCustomer.qr_code_url!;
-      cardToken = existingCustomer.card_token || generateCardToken(customerId);
-      isNewCustomer = false;
-
-      // Update card token if not exists
-      if (!existingCustomer.card_token) {
-        await serviceClient
-          .from('customers')
-          .update({
-            card_token: cardToken,
-            card_token_created_at: new Date().toISOString(),
-          })
-          .eq('id', customerId);
-      }
-
-      // Update name/phone if provided and currently empty
-      await serviceClient
-        .from('customers')
-        .update({
-          full_name: existingCustomer.full_name || input.fullName,
-          phone: input.phone,
-        })
-        .eq('id', customerId);
-    } else {
-      // Create new customer
-      const qrToken = generateQRToken();
-      qrCodeUrl = generateQRCodeUrl(qrToken);
-
-      const { data: newCustomer, error: createError } = await serviceClient
-        .from('customers')
-        .insert({
-          user_id: null,
-          email: input.email,
-          full_name: input.fullName,
-          phone: input.phone,
-          total_points: 0,
-          lifetime_points: 0,
-          tier: 'bronze',
-          qr_code_url: qrCodeUrl,
-          created_by_staff_id: staffInfo.staffId,
-          created_by_business_id: staffInfo.business.id,
-        })
-        .select('id')
-        .single();
-
-      if (createError || !newCustomer) {
-        console.error('Create customer error:', createError);
-        return NextResponse.json(
-          { error: 'Failed to create customer' },
-          { status: 500 },
-        );
-      }
-
-      customerId = newCustomer.id;
-      cardToken = generateCardToken(customerId);
-      isNewCustomer = true;
-
-      // Update with card token
-      await serviceClient
-        .from('customers')
-        .update({
-          card_token: cardToken,
-          card_token_created_at: new Date().toISOString(),
-        })
-        .eq('id', customerId);
+    if (existingByEmail) {
+      return NextResponse.json({
+        success: true,
+        data: { alreadyRegistered: true },
+      });
     }
 
-    // 5b. Link customer to business
-    await serviceClient
-      .from('customer_businesses')
-      .upsert(
-        {
-          customer_id: customerId,
+    // 6. Send invite email
+    const joinCode = staffInfo.business.join_code;
+
+    if (joinCode) {
+      const baseUrl = request.nextUrl.origin;
+      const joinUrl = `${baseUrl}/join/${joinCode}?email=${encodeURIComponent(email)}`;
+
+      // Store verification code with purpose 'staff_invite'
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (serviceClient as any)
+        .from('verification_codes')
+        .insert({
+          email,
+          code: '000000', // placeholder — customer will go through full OTP flow
           business_id: staffInfo.business.id,
-        },
-        { onConflict: 'customer_id,business_id' },
-      );
+          purpose: 'staff_invite',
+          expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(), // 7 days
+          attempts: 0,
+          max_attempts: 5,
+        });
 
-    // 6. Generate QR code image
-    const qrCodeDataUrl = await generateQRCodeDataUrl(qrCodeUrl);
+      await sendCustomerInviteEmail({
+        to: email,
+        businessName: staffInfo.business.name,
+        joinUrl,
+      });
+    }
 
-    // 7. Send welcome email
-    const cardViewUrl = `${process.env.NEXT_PUBLIC_APP_URL}/business/${staffInfo.business.slug}/card?token=${cardToken}`;
-
-    const emailResult = await sendWelcomeEmail({
-      to: input.email,
-      customerName: input.fullName,
-      businessName: staffInfo.business.name,
-      businessLogo: staffInfo.business.logo_url,
-      qrCodeContent: qrCodeUrl,
-      cardViewUrl,
-    });
-
-    // 8. Update email sent tracking
-    await serviceClient
-      .from('customers')
-      .update({
-        email_sent_at: new Date().toISOString(),
-        email_sent_count: existingCustomer
-          ? (existingCustomer as { email_sent_count?: number })
-              .email_sent_count || 0 + 1
-          : 1,
-      })
-      .eq('id', customerId);
-
-    // 9. Log audit event
+    // 7. Log audit event
     await logAuditEvent(serviceClient, {
       userId: user.id,
-      action: isNewCustomer ? 'customer_created' : 'customer_email_resent',
+      action: 'customer_invited',
       businessId: staffInfo.business.id,
       details: {
         staffId: staffInfo.staffId,
-        customerId,
-        customerEmail: input.email,
-        customerName: input.fullName,
-        isNewCustomer,
-        emailSent: emailResult.success,
+        inviteEmail: email,
+        emailSent: !!joinCode,
         processingTimeMs: Date.now() - startTime,
         ipAddress,
-        userAgent,
       },
     });
 
-    // 10. Return success response
     return NextResponse.json({
       success: true,
       data: {
-        customerId,
-        isNewCustomer,
-        customerName: input.fullName,
-        customerEmail: input.email,
-        emailSent: emailResult.success,
-        cardViewUrl,
+        alreadyRegistered: false,
+        emailSent: !!joinCode,
       },
     });
   } catch (error) {
-    console.error('Add customer error:', error);
+    console.error('Invite customer error:', error);
     return NextResponse.json(
       { error: 'Internal server error' },
       { status: 500 },

--- a/apps/web/app/business/[slug]/card/card-page-client.tsx
+++ b/apps/web/app/business/[slug]/card/card-page-client.tsx
@@ -3,10 +3,9 @@
 'use client';
 
 import { useState } from 'react';
-import { SignupForm } from './signup-form';
 import { LookupForm } from './lookup-form';
 import { CardModal } from './card-modal';
-import { Gift, Star, CreditCard } from 'lucide-react';
+import { Gift, Star, CreditCard, ArrowRight } from 'lucide-react';
 
 // ============================================
 // TYPES
@@ -27,6 +26,7 @@ interface CardPageClientProps {
     points_per_purchase: number | null;
     pesos_per_point: number | null;
   };
+  joinCode: string | null;
   initialCardData?: InitialCardData | null;
 }
 
@@ -38,6 +38,7 @@ export function CardPageClient({
   slug,
   businessName,
   business,
+  joinCode,
   initialCardData,
 }: CardPageClientProps) {
   const [showModal, setShowModal] = useState(!!initialCardData);
@@ -52,7 +53,7 @@ export function CardPageClient({
               <CreditCard className="w-6 sm:w-8 h-6 sm:h-8 text-primary" />
             </div>
             <h1 className="text-3xl font-bold text-gray-900 mb-2">
-              Get Your Loyalty Card
+              {businessName} Loyalty
             </h1>
             <p className="text-gray-600">
               Join {businessName}&apos;s rewards program and start earning points today!
@@ -76,9 +77,43 @@ export function CardPageClient({
             </div>
           </div>
 
-          {/* Two-Panel Layout */}
+          {/* Layout: New Customer CTA + Lookup */}
           <div className="grid md:grid-cols-2 gap-6">
-            <SignupForm businessSlug={slug} businessName={businessName} />
+            {/* New Customer — redirect to /join */}
+            {joinCode ? (
+              <div className="bg-white rounded-2xl shadow-lg p-6 border-t-4 border-t-primary border border-gray-100 flex flex-col">
+                <div className="flex items-center gap-2 mb-4">
+                  <CreditCard className="w-5 h-5 text-primary" />
+                  <h2 className="text-lg font-semibold text-gray-900">
+                    New Customer
+                  </h2>
+                </div>
+                <p className="text-sm text-gray-600 mb-6 flex-1">
+                  Sign up with email verification to get your loyalty card and start
+                  earning points.
+                </p>
+                <a
+                  href={`/join/${joinCode}`}
+                  className="w-full py-3 bg-primary text-primary-foreground rounded-lg font-medium hover:bg-primary/90 transition-colors flex items-center justify-center gap-2"
+                >
+                  Get My Card
+                  <ArrowRight className="w-4 h-4" />
+                </a>
+              </div>
+            ) : (
+              <div className="bg-white rounded-2xl shadow-lg p-6 border-t-4 border-t-gray-300 border border-gray-100 flex flex-col">
+                <div className="flex items-center gap-2 mb-4">
+                  <CreditCard className="w-5 h-5 text-gray-400" />
+                  <h2 className="text-lg font-semibold text-gray-900">
+                    New Customer
+                  </h2>
+                </div>
+                <p className="text-sm text-gray-500 flex-1">
+                  Ask staff for a join code or scan the QR code at the store to sign up.
+                </p>
+              </div>
+            )}
+
             <LookupForm businessSlug={slug} businessName={businessName} />
           </div>
 

--- a/apps/web/app/join/[code]/join-page-client.tsx
+++ b/apps/web/app/join/[code]/join-page-client.tsx
@@ -1,0 +1,576 @@
+// apps/web/app/join/[code]/join-page-client.tsx
+
+'use client';
+
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import {
+  Loader2,
+  AlertCircle,
+  Mail,
+  Phone,
+  User,
+  ShieldCheck,
+  Star,
+  Gift,
+  CreditCard,
+  ArrowLeft,
+} from 'lucide-react';
+import { CardModal } from '@/app/business/[slug]/card/card-modal';
+
+// ============================================
+// SCHEMAS
+// ============================================
+
+const Step1Schema = z.object({
+  fullName: z
+    .string()
+    .min(2, 'Name must be at least 2 characters')
+    .max(100, 'Name is too long'),
+  email: z.string().email('Invalid email address'),
+  phone: z
+    .string()
+    .length(11, 'Phone number must be exactly 11 digits')
+    .regex(/^\d+$/, 'Phone number must contain only digits'),
+});
+
+const Step2Schema = z.object({
+  code: z
+    .string()
+    .length(6, 'Code must be 6 digits')
+    .regex(/^\d+$/, 'Code must contain only digits'),
+});
+
+type Step1Input = z.infer<typeof Step1Schema>;
+type Step2Input = z.infer<typeof Step2Schema>;
+
+// ============================================
+// TYPES
+// ============================================
+
+interface JoinPageClientProps {
+  joinCode: string;
+  businessName: string;
+  businessLogo: string | null;
+  pointsPerPurchase: number | null;
+  pesosPerPoint: number | null;
+  prefillEmail: string;
+}
+
+type Step = 'info' | 'verify' | 'success';
+
+interface CardData {
+  customerName: string;
+  phone: string;
+  qrCodeUrl: string;
+  tier: string;
+  totalPoints: number;
+}
+
+// ============================================
+// COMPONENT
+// ============================================
+
+export function JoinPageClient({
+  joinCode,
+  businessName,
+  businessLogo,
+  pointsPerPurchase,
+  pesosPerPoint,
+  prefillEmail,
+}: JoinPageClientProps) {
+  const [step, setStep] = useState<Step>('info');
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [formData, setFormData] = useState<Step1Input | null>(null);
+  const [cardData, setCardData] = useState<CardData | null>(null);
+  const [showCardModal, setShowCardModal] = useState(false);
+  const [resendCooldown, setResendCooldown] = useState(0);
+
+  // Step 1 form
+  const step1Form = useForm<Step1Input>({
+    resolver: zodResolver(Step1Schema),
+    defaultValues: {
+      fullName: '',
+      email: prefillEmail,
+      phone: '',
+    },
+  });
+
+  // Step 2 form
+  const step2Form = useForm<Step2Input>({
+    resolver: zodResolver(Step2Schema),
+    defaultValues: { code: '' },
+  });
+
+  // ============================================
+  // STEP 1: Submit info + send OTP
+  // ============================================
+
+  const onStep1Submit = async (data: Step1Input) => {
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const response = await fetch('/api/public/verify/send', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: data.email,
+          joinCode,
+        }),
+      });
+
+      const json = await response.json();
+
+      if (!response.ok) {
+        setError(json.error || 'Failed to send verification code');
+        return;
+      }
+
+      setFormData(data);
+      setStep('verify');
+      startResendCooldown();
+    } catch {
+      setError('Network error. Please check your connection.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // ============================================
+  // STEP 2: Verify OTP
+  // ============================================
+
+  const onStep2Submit = async (data: Step2Input) => {
+    if (!formData) return;
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      // Verify the code
+      const verifyResponse = await fetch('/api/public/verify/check', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          code: data.code,
+          email: formData.email,
+          joinCode,
+        }),
+      });
+
+      const verifyJson = await verifyResponse.json();
+
+      if (!verifyResponse.ok) {
+        setError(verifyJson.message || verifyJson.error || 'Invalid code');
+        return;
+      }
+
+      // Create customer
+      const signupResponse = await fetch(`/api/public/join/${joinCode}/signup`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          fullName: formData.fullName,
+          phone: formData.phone,
+          email: formData.email,
+        }),
+      });
+
+      const signupJson = await signupResponse.json();
+
+      if (!signupResponse.ok) {
+        setError(signupJson.error || 'Failed to create account');
+        return;
+      }
+
+      // Success!
+      setCardData({
+        customerName: signupJson.data.customerName,
+        phone: formData.phone,
+        qrCodeUrl: signupJson.data.qrCodeUrl,
+        tier: signupJson.data.tier,
+        totalPoints: signupJson.data.totalPoints,
+      });
+      setStep('success');
+      setShowCardModal(true);
+    } catch {
+      setError('Network error. Please check your connection.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // ============================================
+  // RESEND CODE
+  // ============================================
+
+  const handleResend = async () => {
+    if (resendCooldown > 0 || !formData) return;
+
+    setError(null);
+    try {
+      const response = await fetch('/api/public/verify/send', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: formData.email,
+          joinCode,
+        }),
+      });
+
+      const json = await response.json();
+
+      if (!response.ok) {
+        setError(json.error || 'Failed to resend code');
+        return;
+      }
+
+      startResendCooldown();
+    } catch {
+      setError('Network error.');
+    }
+  };
+
+  const startResendCooldown = () => {
+    setResendCooldown(60);
+    const interval = setInterval(() => {
+      setResendCooldown((prev) => {
+        if (prev <= 1) {
+          clearInterval(interval);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+  };
+
+  // ============================================
+  // RENDER
+  // ============================================
+
+  return (
+    <>
+      <div className="min-h-screen bg-gray-50 flex flex-col">
+        {/* Header */}
+        <div className="bg-[#7F0404] py-6 px-4 text-center">
+          {businessLogo ? (
+            <img
+              src={businessLogo}
+              alt={businessName}
+              className="h-12 mx-auto mb-2"
+            />
+          ) : (
+            <h1 className="text-2xl font-bold text-white">{businessName}</h1>
+          )}
+          <p className="text-white/80 text-sm">Loyalty Rewards Program</p>
+        </div>
+
+        <div className="flex-1 container mx-auto px-4 py-8 max-w-md">
+          {/* Benefits (only on step 1) */}
+          {step === 'info' && (
+            <div className="grid grid-cols-2 gap-3 mb-6">
+              <div className="bg-white border border-gray-200 rounded-xl p-3 text-center">
+                <Star className="w-5 h-5 text-yellow-500 mx-auto mb-1" />
+                <p className="text-xs font-medium text-gray-900">Earn Points</p>
+                <p className="text-[10px] text-gray-500">
+                  {pointsPerPurchase || 1} pt per{' '}
+                  {pesosPerPoint ? `P${pesosPerPoint}` : 'purchase'}
+                </p>
+              </div>
+              <div className="bg-white border border-gray-200 rounded-xl p-3 text-center">
+                <Gift className="w-5 h-5 text-primary mx-auto mb-1" />
+                <p className="text-xs font-medium text-gray-900">Get Rewards</p>
+                <p className="text-[10px] text-gray-500">
+                  Redeem for exclusive perks
+                </p>
+              </div>
+            </div>
+          )}
+
+          {/* STEP 1: Customer Info */}
+          {step === 'info' && (
+            <form
+              onSubmit={step1Form.handleSubmit(onStep1Submit)}
+              className="bg-white rounded-2xl shadow-lg p-6 border border-gray-100"
+            >
+              <div className="flex items-center gap-2 mb-5">
+                <CreditCard className="w-5 h-5 text-primary" />
+                <h2 className="text-lg font-semibold text-gray-900">
+                  Get Your Loyalty Card
+                </h2>
+              </div>
+
+              {error && (
+                <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg flex items-start gap-2">
+                  <AlertCircle className="w-4 h-4 text-red-500 shrink-0 mt-0.5" />
+                  <p className="text-sm text-red-700">{error}</p>
+                </div>
+              )}
+
+              {/* Full Name */}
+              <div className="mb-4">
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Full Name <span className="text-red-500">*</span>
+                </label>
+                <div className="relative">
+                  <User className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                  <input
+                    {...step1Form.register('fullName')}
+                    type="text"
+                    placeholder="Juan Dela Cruz"
+                    disabled={isSubmitting}
+                    className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-xl bg-white text-gray-900 placeholder:text-gray-400 focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors"
+                  />
+                </div>
+                {step1Form.formState.errors.fullName && (
+                  <p className="mt-1 text-xs text-red-500">
+                    {step1Form.formState.errors.fullName.message}
+                  </p>
+                )}
+              </div>
+
+              {/* Email */}
+              <div className="mb-4">
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Email <span className="text-red-500">*</span>
+                </label>
+                <div className="relative">
+                  <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                  <input
+                    {...step1Form.register('email')}
+                    type="email"
+                    placeholder="juan@email.com"
+                    disabled={isSubmitting}
+                    className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-xl bg-white text-gray-900 placeholder:text-gray-400 focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors"
+                  />
+                </div>
+                {step1Form.formState.errors.email && (
+                  <p className="mt-1 text-xs text-red-500">
+                    {step1Form.formState.errors.email.message}
+                  </p>
+                )}
+              </div>
+
+              {/* Phone */}
+              <div className="mb-6">
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Phone Number <span className="text-red-500">*</span>
+                </label>
+                <div className="relative">
+                  <Phone className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                  <input
+                    {...step1Form.register('phone')}
+                    type="tel"
+                    inputMode="numeric"
+                    maxLength={11}
+                    placeholder="09171234567"
+                    disabled={isSubmitting}
+                    className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-xl bg-white text-gray-900 placeholder:text-gray-400 focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors"
+                    onKeyDown={(e) => {
+                      if (
+                        [
+                          'Backspace',
+                          'Delete',
+                          'Tab',
+                          'Escape',
+                          'Enter',
+                          'ArrowLeft',
+                          'ArrowRight',
+                        ].includes(e.key)
+                      )
+                        return;
+                      if (!/^\d$/.test(e.key)) e.preventDefault();
+                    }}
+                  />
+                </div>
+                {step1Form.formState.errors.phone && (
+                  <p className="mt-1 text-xs text-red-500">
+                    {step1Form.formState.errors.phone.message}
+                  </p>
+                )}
+              </div>
+
+              <button
+                type="submit"
+                disabled={isSubmitting}
+                className="w-full py-3.5 bg-primary text-primary-foreground rounded-xl font-semibold hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+              >
+                {isSubmitting ? (
+                  <>
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    Sending code...
+                  </>
+                ) : (
+                  <>
+                    <Mail className="w-4 h-4" />
+                    Verify Email & Continue
+                  </>
+                )}
+              </button>
+
+              <p className="mt-4 text-xs text-center text-gray-500">
+                We&apos;ll send a 6-digit code to verify your email address.
+              </p>
+            </form>
+          )}
+
+          {/* STEP 2: Enter OTP */}
+          {step === 'verify' && (
+            <form
+              onSubmit={step2Form.handleSubmit(onStep2Submit)}
+              className="bg-white rounded-2xl shadow-lg p-6 border border-gray-100"
+            >
+              <button
+                type="button"
+                onClick={() => {
+                  setStep('info');
+                  setError(null);
+                  step2Form.reset();
+                }}
+                className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 mb-4 transition-colors"
+              >
+                <ArrowLeft className="w-4 h-4" />
+                Back
+              </button>
+
+              <div className="flex items-center gap-2 mb-2">
+                <ShieldCheck className="w-5 h-5 text-primary" />
+                <h2 className="text-lg font-semibold text-gray-900">
+                  Verify Your Email
+                </h2>
+              </div>
+              <p className="text-sm text-gray-500 mb-5">
+                We sent a 6-digit code to{' '}
+                <strong className="text-gray-700">{formData?.email}</strong>
+              </p>
+
+              {error && (
+                <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg flex items-start gap-2">
+                  <AlertCircle className="w-4 h-4 text-red-500 shrink-0 mt-0.5" />
+                  <p className="text-sm text-red-700">{error}</p>
+                </div>
+              )}
+
+              {/* Code Input */}
+              <div className="mb-6">
+                <input
+                  {...step2Form.register('code')}
+                  type="text"
+                  inputMode="numeric"
+                  maxLength={6}
+                  placeholder="000000"
+                  autoComplete="one-time-code"
+                  disabled={isSubmitting}
+                  className="w-full py-4 text-center text-3xl font-mono font-bold tracking-[0.5em] border border-gray-300 rounded-xl bg-white text-gray-900 placeholder:text-gray-300 focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors"
+                  onKeyDown={(e) => {
+                    if (
+                      [
+                        'Backspace',
+                        'Delete',
+                        'Tab',
+                        'Escape',
+                        'Enter',
+                        'ArrowLeft',
+                        'ArrowRight',
+                      ].includes(e.key)
+                    )
+                      return;
+                    if (!/^\d$/.test(e.key)) e.preventDefault();
+                  }}
+                />
+                {step2Form.formState.errors.code && (
+                  <p className="mt-1 text-xs text-red-500 text-center">
+                    {step2Form.formState.errors.code.message}
+                  </p>
+                )}
+              </div>
+
+              <button
+                type="submit"
+                disabled={isSubmitting}
+                className="w-full py-3.5 bg-primary text-primary-foreground rounded-xl font-semibold hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+              >
+                {isSubmitting ? (
+                  <>
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    Verifying...
+                  </>
+                ) : (
+                  <>
+                    <ShieldCheck className="w-4 h-4" />
+                    Verify & Get Card
+                  </>
+                )}
+              </button>
+
+              {/* Resend */}
+              <div className="mt-4 text-center">
+                {resendCooldown > 0 ? (
+                  <p className="text-xs text-gray-400">
+                    Resend code in {resendCooldown}s
+                  </p>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={handleResend}
+                    className="text-xs text-primary hover:underline"
+                  >
+                    Didn&apos;t receive the code? Resend
+                  </button>
+                )}
+              </div>
+            </form>
+          )}
+
+          {/* STEP 3: Success */}
+          {step === 'success' && cardData && (
+            <div className="bg-white rounded-2xl shadow-lg p-6 border border-gray-100 text-center">
+              <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                <ShieldCheck className="w-8 h-8 text-green-600" />
+              </div>
+              <h2 className="text-xl font-bold text-gray-900 mb-2">
+                Welcome to {businessName}!
+              </h2>
+              <p className="text-sm text-gray-500 mb-6">
+                Your loyalty card is ready. Show the QR code at checkout to earn
+                points!
+              </p>
+              <button
+                onClick={() => setShowCardModal(true)}
+                className="w-full py-3.5 bg-primary text-primary-foreground rounded-xl font-semibold hover:bg-primary/90 transition-colors flex items-center justify-center gap-2"
+              >
+                <CreditCard className="w-4 h-4" />
+                View My Card
+              </button>
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <footer className="py-4 text-center">
+          <p className="text-xs text-gray-400">
+            Powered by <span className="font-semibold text-gray-500">NoxaLoyalty</span>
+          </p>
+        </footer>
+      </div>
+
+      {/* Card Modal */}
+      {cardData && (
+        <CardModal
+          isOpen={showCardModal}
+          onClose={() => setShowCardModal(false)}
+          customerName={cardData.customerName}
+          businessName={businessName}
+          phone={cardData.phone}
+          qrCodeUrl={cardData.qrCodeUrl}
+          tier={cardData.tier}
+          totalPoints={cardData.totalPoints}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/web/app/join/[code]/page.tsx
+++ b/apps/web/app/join/[code]/page.tsx
@@ -1,0 +1,32 @@
+// apps/web/app/join/[code]/page.tsx
+
+import { notFound } from 'next/navigation';
+import { getBusinessByJoinCode } from '@/lib/services/public-business.service';
+import { JoinPageClient } from './join-page-client';
+
+interface JoinPageProps {
+  params: Promise<{ code: string }>;
+  searchParams: Promise<{ email?: string }>;
+}
+
+export default async function JoinPage({ params, searchParams }: JoinPageProps) {
+  const { code } = await params;
+  const { email } = await searchParams;
+
+  const business = await getBusinessByJoinCode(code);
+
+  if (!business) {
+    notFound();
+  }
+
+  return (
+    <JoinPageClient
+      joinCode={code}
+      businessName={business.name}
+      businessLogo={business.logo_url}
+      pointsPerPurchase={business.points_per_purchase}
+      pesosPerPoint={business.pesos_per_point}
+      prefillEmail={email || ''}
+    />
+  );
+}

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -51,7 +51,7 @@ export default function NotFound() {
           </p>
 
           <div className="flex items-center justify-center gap-3">
-            <Button variant="outline" onClick={() => router.back()}>
+            <Button className='text-black' variant="outline" onClick={() => router.back()}>
               <ArrowLeft className="mr-2 h-4 w-4" />
               Go Back
             </Button>

--- a/apps/web/components/customers/add-customer-modal.tsx
+++ b/apps/web/components/customers/add-customer-modal.tsx
@@ -14,14 +14,11 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { motion } from 'framer-motion';
 import {
-  User,
   Mail,
-  Phone,
-  Calendar,
   Loader2,
   CheckCircle,
   AlertCircle,
-  UserPlus,
+  Send,
 } from 'lucide-react';
 
 // ============================================
@@ -35,17 +32,11 @@ interface AddCustomerModalProps {
 }
 
 interface FormData {
-  fullName: string;
   email: string;
-  phone: string;
-  age: string;
 }
 
 interface FormErrors {
-  fullName?: string;
   email?: string;
-  phone?: string;
-  age?: string;
 }
 
 type SubmitState = 'idle' | 'submitting' | 'success' | 'error';
@@ -57,29 +48,13 @@ type SubmitState = 'idle' | 'submitting' | 'success' | 'error';
 function validateForm(data: FormData): FormErrors {
   const errors: FormErrors = {};
 
-  if (!data.fullName.trim()) {
-    errors.fullName = 'Name is required';
-  } else if (data.fullName.trim().length < 2) {
-    errors.fullName = 'Name must be at least 2 characters';
-  }
-
   if (!data.email.trim()) {
     errors.email = 'Email is required';
-  } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(data.email)) {
+    return errors;
+  }
+
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(data.email)) {
     errors.email = 'Invalid email address';
-  }
-
-  if (!data.phone.trim()) {
-    errors.phone = 'Phone number is required';
-  } else if (!/^[\d\s\-+()]{10,20}$/.test(data.phone)) {
-    errors.phone = 'Invalid phone number';
-  }
-
-  if (data.age) {
-    const ageNum = parseInt(data.age);
-    if (isNaN(ageNum) || ageNum < 13 || ageNum > 120) {
-      errors.age = 'Age must be between 13 and 120';
-    }
   }
 
   return errors;
@@ -95,20 +70,16 @@ export function AddCustomerModal({
   businessName,
 }: AddCustomerModalProps) {
   const [formData, setFormData] = useState<FormData>({
-    fullName: '',
     email: '',
-    phone: '',
-    age: '',
   });
   const [errors, setErrors] = useState<FormErrors>({});
   const [submitState, setSubmitState] = useState<SubmitState>('idle');
   const [submitMessage, setSubmitMessage] = useState('');
-  const [isNewCustomer, setIsNewCustomer] = useState(false);
 
-  const handleInputChange = (field: keyof FormData, value: string) => {
-    setFormData((prev) => ({ ...prev, [field]: value }));
-    if (errors[field]) {
-      setErrors((prev) => ({ ...prev, [field]: undefined }));
+  const handleInputChange = (value: string) => {
+    setFormData({ email: value });
+    if (errors.email) {
+      setErrors({});
     }
   };
 
@@ -127,44 +98,40 @@ export function AddCustomerModal({
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          fullName: formData.fullName.trim(),
           email: formData.email.trim().toLowerCase(),
-          phone: formData.phone.trim(),
-          age: formData.age ? parseInt(formData.age) : undefined,
         }),
       });
 
       const data = await response.json();
 
       if (!response.ok) {
-        throw new Error(data.error || 'Failed to add customer');
+        throw new Error(data.error || 'Failed to send invitation');
       }
 
-      setIsNewCustomer(data.data.isNewCustomer);
       setSubmitMessage(
-        data.data.isNewCustomer
-          ? `Customer added successfully! Email sent to ${data.data.customerEmail}.`
-          : `Customer already exists. Email re-sent to ${data.data.customerEmail}.`
+        data.data.alreadyRegistered
+          ? `This customer is already registered with ${businessName}.`
+          : `Invitation sent! The customer will receive an email to complete their signup.`,
       );
       setSubmitState('success');
     } catch (error) {
       setSubmitMessage(
-        error instanceof Error ? error.message : 'Something went wrong'
+        error instanceof Error ? error.message : 'Something went wrong',
       );
       setSubmitState('error');
     }
   };
 
   const handleClose = () => {
-    setFormData({ fullName: '', email: '', phone: '', age: '' });
+    setFormData({ email: '' });
     setErrors({});
     setSubmitState('idle');
     setSubmitMessage('');
     onClose();
   };
 
-  const handleAddAnother = () => {
-    setFormData({ fullName: '', email: '', phone: '', age: '' });
+  const handleInviteAnother = () => {
+    setFormData({ email: '' });
     setErrors({});
     setSubmitState('idle');
     setSubmitMessage('');
@@ -175,8 +142,8 @@ export function AddCustomerModal({
       <DialogContent className="max-w-md">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <UserPlus className="w-5 h-5 text-primary" />
-            Add Customer
+            <Send className="w-5 h-5 text-primary" />
+            Invite Customer
           </DialogTitle>
         </DialogHeader>
 
@@ -190,19 +157,17 @@ export function AddCustomerModal({
               <div className="w-16 h-16 bg-green-500/20 rounded-full flex items-center justify-center mx-auto mb-4">
                 <CheckCircle className="w-8 h-8 text-green-500" />
               </div>
-              <h3 className="text-xl font-semibold mb-2">
-                {isNewCustomer ? 'Customer Added!' : 'Email Sent!'}
-              </h3>
+              <h3 className="text-xl font-semibold mb-2">Done!</h3>
               <p className="text-gray-500 text-sm mb-6">
                 {submitMessage}
               </p>
               <div className="flex gap-3">
                 <Button
                   variant="outline"
-                  onClick={handleAddAnother}
+                  onClick={handleInviteAnother}
                   className="flex-1"
                 >
-                  Add Another
+                  Invite Another
                 </Button>
                 <Button onClick={handleClose} className="flex-1">
                   Done
@@ -228,34 +193,15 @@ export function AddCustomerModal({
             </div>
           ) : (
             <div className="space-y-4">
-              {/* Full Name */}
-              <div className="space-y-2">
-                <Label htmlFor="fullName" className="text-gray-700">
-                  Full Name <span className="text-red-600">*</span>
-                </Label>
-                <div className="relative">
-                  <User className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
-                  <Input
-                    id="fullName"
-                    value={formData.fullName}
-                    onChange={(e) =>
-                      handleInputChange('fullName', e.target.value)
-                    }
-                    placeholder="Juan Dela Cruz"
-                    className={`pl-10 ${
-                      errors.fullName ? 'border-red-500' : ''
-                    }`}
-                  />
-                </div>
-                {errors.fullName && (
-                  <p className="text-xs text-red-600">{errors.fullName}</p>
-                )}
-              </div>
+              <p className="text-sm text-muted-foreground">
+                Enter the customer&apos;s email address. They&apos;ll receive
+                an invitation to sign up and verify their identity.
+              </p>
 
               {/* Email */}
               <div className="space-y-2">
                 <Label htmlFor="email" className="text-gray-700">
-                  Email Address <span className="text-red-600">*</span>
+                  Email Address
                 </Label>
                 <div className="relative">
                   <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
@@ -263,7 +209,7 @@ export function AddCustomerModal({
                     id="email"
                     type="email"
                     value={formData.email}
-                    onChange={(e) => handleInputChange('email', e.target.value)}
+                    onChange={(e) => handleInputChange(e.target.value)}
                     placeholder="juan@email.com"
                     className={`pl-10 ${
                       errors.email ? 'border-red-500' : ''
@@ -275,59 +221,11 @@ export function AddCustomerModal({
                 )}
               </div>
 
-              {/* Phone */}
-              <div className="space-y-2">
-                <Label htmlFor="phone" className="text-gray-700">
-                  Mobile Number <span className="text-red-600">*</span>
-                </Label>
-                <div className="relative">
-                  <Phone className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
-                  <Input
-                    id="phone"
-                    type="tel"
-                    value={formData.phone}
-                    onChange={(e) => handleInputChange('phone', e.target.value)}
-                    placeholder="09123456789"
-                    className={`pl-10 ${
-                      errors.phone ? 'border-red-500' : ''
-                    }`}
-                  />
-                </div>
-                {errors.phone && (
-                  <p className="text-xs text-red-600">{errors.phone}</p>
-                )}
-              </div>
-
-              {/* Age */}
-              <div className="space-y-2">
-                <Label htmlFor="age" className="text-gray-700">
-                  Age <span className="text-gray-500">(optional)</span>
-                </Label>
-                <div className="relative">
-                  <Calendar className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
-                  <Input
-                    id="age"
-                    type="number"
-                    value={formData.age}
-                    onChange={(e) => handleInputChange('age', e.target.value)}
-                    placeholder="25"
-                    min="13"
-                    max="120"
-                    className={`pl-10 ${
-                      errors.age ? 'border-red-500' : ''
-                    }`}
-                  />
-                </div>
-                {errors.age && (
-                  <p className="text-xs text-red-600">{errors.age}</p>
-                )}
-              </div>
-
               {/* Info Box */}
               <div className="bg-primary/10 border border-primary/20 rounded-lg p-3">
                 <p className="text-xs text-primary">
-                  📧 Customer will receive an email with their QR code and
-                  loyalty card.
+                  The customer will complete their registration on their own device.
+                  Their identity will be verified via email OTP.
                 </p>
               </div>
 
@@ -340,12 +238,12 @@ export function AddCustomerModal({
                 {submitState === 'submitting' ? (
                   <>
                     <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                    Adding Customer...
+                    Sending Invitation...
                   </>
                 ) : (
                   <>
-                    <UserPlus className="w-4 h-4 mr-2" />
-                    Add Customer & Send Email
+                    <Send className="w-4 h-4 mr-2" />
+                    Send Invitation
                   </>
                 )}
               </Button>

--- a/apps/web/components/staff/add-customer-modal.tsx
+++ b/apps/web/components/staff/add-customer-modal.tsx
@@ -5,11 +5,8 @@
 import { useState } from 'react';
 import {
   X,
-  UserPlus,
+  Send,
   Mail,
-  Phone,
-  User,
-  Calendar,
   Loader2,
   CheckCircle,
   AlertCircle,
@@ -26,17 +23,11 @@ interface AddCustomerModalProps {
 }
 
 interface FormData {
-  fullName: string;
   email: string;
-  phone: string;
-  age: string;
 }
 
 interface FormErrors {
-  fullName?: string;
   email?: string;
-  phone?: string;
-  age?: string;
 }
 
 type SubmitState = 'idle' | 'submitting' | 'success' | 'error';
@@ -48,31 +39,13 @@ type SubmitState = 'idle' | 'submitting' | 'success' | 'error';
 function validateForm(data: FormData): FormErrors {
   const errors: FormErrors = {};
 
-  if (!data.fullName.trim()) {
-    errors.fullName = 'Name is required';
-  } else if (data.fullName.trim().length < 2) {
-    errors.fullName = 'Name must be at least 2 characters';
-  } else if (!/^[a-zA-Z\s\-'.]+$/.test(data.fullName)) {
-    errors.fullName = 'Name contains invalid characters';
-  }
-
   if (!data.email.trim()) {
     errors.email = 'Email is required';
-  } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(data.email)) {
+    return errors;
+  }
+
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(data.email)) {
     errors.email = 'Invalid email address';
-  }
-
-  if (!data.phone.trim()) {
-    errors.phone = 'Phone number is required';
-  } else if (!/^\d{11}$/.test(data.phone)) {
-    errors.phone = 'Phone number must be exactly 11 digits';
-  }
-
-  if (data.age) {
-    const ageNum = parseInt(data.age);
-    if (isNaN(ageNum) || ageNum < 13 || ageNum > 120) {
-      errors.age = 'Age must be between 13 and 120';
-    }
   }
 
   return errors;
@@ -88,29 +61,20 @@ export function AddCustomerModal({
   businessName,
 }: AddCustomerModalProps) {
   const [formData, setFormData] = useState<FormData>({
-    fullName: '',
     email: '',
-    phone: '',
-    age: '',
   });
   const [errors, setErrors] = useState<FormErrors>({});
   const [submitState, setSubmitState] = useState<SubmitState>('idle');
   const [submitMessage, setSubmitMessage] = useState('');
-  const [isNewCustomer, setIsNewCustomer] = useState(false);
 
-  const handleInputChange = (field: keyof FormData, value: string) => {
-    if (field === 'phone') {
-      value = value.replace(/\D/g, '').slice(0, 11);
-    }
-    setFormData((prev) => ({ ...prev, [field]: value }));
-    // Clear error when user types
-    if (errors[field]) {
-      setErrors((prev) => ({ ...prev, [field]: undefined }));
+  const handleInputChange = (value: string) => {
+    setFormData({ email: value });
+    if (errors.email) {
+      setErrors({});
     }
   };
 
   const handleSubmit = async () => {
-    // Validate
     const validationErrors = validateForm(formData);
     if (Object.keys(validationErrors).length > 0) {
       setErrors(validationErrors);
@@ -125,24 +89,20 @@ export function AddCustomerModal({
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          fullName: formData.fullName.trim(),
           email: formData.email.trim().toLowerCase(),
-          phone: formData.phone.trim(),
-          age: formData.age ? parseInt(formData.age) : undefined,
         }),
       });
 
       const data = await response.json();
 
       if (!response.ok) {
-        throw new Error(data.error || 'Failed to add customer');
+        throw new Error(data.error || 'Failed to send invitation');
       }
 
-      setIsNewCustomer(data.data.isNewCustomer);
       setSubmitMessage(
-        data.data.isNewCustomer
-          ? `Customer added successfully! A welcome email has been sent to ${data.data.customerEmail}.`
-          : `Customer already exists. A reminder email has been sent to ${data.data.customerEmail}.`,
+        data.data.alreadyRegistered
+          ? `This customer is already registered with ${businessName}.`
+          : `Invitation sent! The customer will receive an email to complete their signup.`,
       );
       setSubmitState('success');
     } catch (error) {
@@ -154,16 +114,15 @@ export function AddCustomerModal({
   };
 
   const handleClose = () => {
-    // Reset form
-    setFormData({ fullName: '', email: '', phone: '', age: '' });
+    setFormData({ email: '' });
     setErrors({});
     setSubmitState('idle');
     setSubmitMessage('');
     onClose();
   };
 
-  const handleAddAnother = () => {
-    setFormData({ fullName: '', email: '', phone: '', age: '' });
+  const handleInviteAnother = () => {
+    setFormData({ email: '' });
     setErrors({});
     setSubmitState('idle');
     setSubmitMessage('');
@@ -185,10 +144,10 @@ export function AddCustomerModal({
         <div className="flex items-center justify-between p-5 border-b border-gray-200 bg-[#7F0404]">
           <div className="flex items-center gap-3">
             <div className="w-10 h-10 bg-white/20 rounded-full flex items-center justify-center">
-              <UserPlus className="w-5 h-5 text-white" />
+              <Send className="w-5 h-5 text-white" />
             </div>
             <div>
-              <h2 className="text-lg font-semibold text-white">Add Customer</h2>
+              <h2 className="text-lg font-semibold text-white">Invite Customer</h2>
               <p className="text-xs text-white/70">{businessName}</p>
             </div>
           </div>
@@ -203,21 +162,20 @@ export function AddCustomerModal({
         {/* Content */}
         <div className="p-5">
           {submitState === 'success' ? (
-            // Success State
             <div className="text-center py-6">
               <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
                 <CheckCircle className="w-8 h-8 text-green-600" />
               </div>
               <h3 className="text-xl font-semibold text-gray-900 mb-2">
-                {isNewCustomer ? 'Customer Added!' : 'Email Sent!'}
+                Done!
               </h3>
               <p className="text-gray-500 text-sm mb-6">{submitMessage}</p>
               <div className="flex gap-3">
                 <button
-                  onClick={handleAddAnother}
+                  onClick={handleInviteAnother}
                   className="flex-1 py-3 bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-xl font-medium transition-colors border border-gray-300"
                 >
-                  Add Another
+                  Invite Another
                 </button>
                 <button
                   onClick={handleClose}
@@ -228,7 +186,6 @@ export function AddCustomerModal({
               </div>
             </div>
           ) : submitState === 'error' ? (
-            // Error State
             <div className="text-center py-6">
               <div className="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mx-auto mb-4">
                 <AlertCircle className="w-8 h-8 text-red-600" />
@@ -243,45 +200,23 @@ export function AddCustomerModal({
               </button>
             </div>
           ) : (
-            // Form State
             <div className="space-y-4">
-              {/* Full Name */}
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1.5">
-                  Full Name <span className="text-red-500">*</span>
-                </label>
-                <div className="relative">
-                  <User className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
-                  <input
-                    type="text"
-                    value={formData.fullName}
-                    onChange={(e) =>
-                      handleInputChange('fullName', e.target.value)
-                    }
-                    placeholder="Juan Dela Cruz"
-                    className={`w-full pl-10 pr-4 py-3 bg-white border rounded-xl text-gray-900 placeholder-gray-400 focus:ring-2 focus:ring-yellow-400/50 transition-all ${
-                      errors.fullName
-                        ? 'border-red-500'
-                        : 'border-gray-300 focus:border-yellow-400'
-                    }`}
-                  />
-                </div>
-                {errors.fullName && (
-                  <p className="mt-1 text-xs text-red-500">{errors.fullName}</p>
-                )}
-              </div>
+              <p className="text-sm text-gray-600">
+                Enter the customer&apos;s email address. They&apos;ll receive an
+                invitation to sign up on their own device.
+              </p>
 
               {/* Email */}
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1.5">
-                  Email Address <span className="text-red-500">*</span>
+                  Email Address
                 </label>
                 <div className="relative">
                   <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
                   <input
                     type="email"
                     value={formData.email}
-                    onChange={(e) => handleInputChange('email', e.target.value)}
+                    onChange={(e) => handleInputChange(e.target.value)}
                     placeholder="juan@email.com"
                     className={`w-full pl-10 pr-4 py-3 bg-white border rounded-xl text-gray-900 placeholder-gray-400 focus:ring-2 focus:ring-yellow-400/50 transition-all ${
                       errors.email
@@ -295,63 +230,11 @@ export function AddCustomerModal({
                 )}
               </div>
 
-              {/* Phone */}
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1.5">
-                  Mobile Number <span className="text-red-500">*</span>
-                </label>
-                <div className="relative">
-                  <Phone className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
-                  <input
-                    type="tel"
-                    value={formData.phone}
-                    onChange={(e) => handleInputChange('phone', e.target.value)}
-                    placeholder="09123456789"
-                    maxLength={11}
-                    className={`w-full pl-10 pr-4 py-3 bg-white border rounded-xl text-gray-900 placeholder-gray-400 focus:ring-2 focus:ring-yellow-400/50 transition-all ${
-                      errors.phone
-                        ? 'border-red-500'
-                        : 'border-gray-300 focus:border-yellow-400'
-                    }`}
-                  />
-                </div>
-                {errors.phone && (
-                  <p className="mt-1 text-xs text-red-500">{errors.phone}</p>
-                )}
-              </div>
-
-              {/* Age (Optional) */}
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1.5">
-                  Age <span className="text-gray-400">(optional)</span>
-                </label>
-                <div className="relative">
-                  <Calendar className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
-                  <input
-                    type="number"
-                    value={formData.age}
-                    onChange={(e) => handleInputChange('age', e.target.value)}
-                    placeholder="25"
-                    min="13"
-                    max="120"
-                    className={`w-full pl-10 pr-4 py-3 bg-white border rounded-xl text-gray-900 placeholder-gray-400 focus:ring-2 focus:ring-yellow-400/50 transition-all ${
-                      errors.age
-                        ? 'border-red-500'
-                        : 'border-gray-300 focus:border-yellow-400'
-                    }`}
-                  />
-                </div>
-                {errors.age && (
-                  <p className="mt-1 text-xs text-red-500">{errors.age}</p>
-                )}
-              </div>
-
               {/* Info Box */}
               <div className="bg-yellow-50 border border-yellow-200 rounded-xl p-4">
                 <p className="text-xs text-gray-700">
-                  📧 Customer will receive an email with their QR code and
-                  loyalty card. They can use the same email to log in to the
-                  NoxaLoyalty app later.
+                  The customer will complete their registration on their own device.
+                  Their identity will be verified via email OTP.
                 </p>
               </div>
 
@@ -364,12 +247,12 @@ export function AddCustomerModal({
                 {submitState === 'submitting' ? (
                   <>
                     <Loader2 className="w-5 h-5 animate-spin" />
-                    Adding Customer...
+                    Sending Invitation...
                   </>
                 ) : (
                   <>
-                    <UserPlus className="w-5 h-5" />
-                    Add Customer & Send Email
+                    <Send className="w-5 h-5" />
+                    Send Invitation
                   </>
                 )}
               </button>

--- a/apps/web/components/staff/idle-view.tsx
+++ b/apps/web/components/staff/idle-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { QrCode, UserPlus, CheckCircle } from "lucide-react";
+import { QrCode, Send, CheckCircle } from "lucide-react";
 import { motion } from "framer-motion";
 
 interface IdleViewProps {
@@ -35,8 +35,8 @@ export function IdleView({
           onClick={onAddCustomer}
           className="flex items-center gap-2 px-5 py-3 bg-white hover:bg-gray-50 border border-gray-300 rounded-xl transition-colors shadow-sm"
         >
-          <UserPlus className="w-5 h-5 text-yellow-600" />
-          <span className="text-gray-700 text-sm">Add Customer</span>
+          <Send className="w-5 h-5 text-yellow-600" />
+          <span className="text-gray-700 text-sm">Invite Customer</span>
         </button>
         <button
           onClick={onVerifyCode}
@@ -47,7 +47,7 @@ export function IdleView({
         </button>
       </div>
       <p className="text-gray-500 text-xs">
-        Add customers or verify redemption codes
+        Invite customers or verify redemption codes
       </p>
     </div>
   );

--- a/apps/web/lib/qr-code.ts
+++ b/apps/web/lib/qr-code.ts
@@ -79,6 +79,19 @@ export async function generateQRCodeBuffer(content: string): Promise<Buffer> {
 }
 
 // ============================================
+// BUSINESS JOIN QR CODE
+// ============================================
+
+/**
+ * Generate a URL for the business join page
+ * Customers scan this QR to self-register
+ */
+export function generateBusinessJoinQRCodeUrl(joinCode: string): string {
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+  return `${appUrl}/join/${joinCode}`;
+}
+
+// ============================================
 // CARD TOKEN (HMAC-SIGNED)
 // ============================================
 

--- a/apps/web/lib/services/public-business.service.ts
+++ b/apps/web/lib/services/public-business.service.ts
@@ -112,7 +112,58 @@ export async function getBusinessBySlug(
     `
     )
     .eq('slug', slug)
-    .in('subscription_status', ['active', 'trialing'])
+    .in('subscription_status', ['active', 'trialing', 'free_forever'])
+    .single();
+
+  if (error || !data) {
+    return null;
+  }
+
+  return {
+    id: data.id,
+    name: data.name,
+    slug: data.slug,
+    description: data.description,
+    logo_url: data.logo_url,
+    business_type: data.business_type,
+    address: data.address,
+    city: data.city,
+    phone: data.phone,
+    points_per_purchase: data.points_per_purchase,
+    pesos_per_point: data.pesos_per_point,
+  };
+}
+
+// ============================================
+// GET BUSINESS BY JOIN CODE
+// ============================================
+
+export async function getBusinessByJoinCode(
+  joinCode: string,
+): Promise<PublicBusiness | null> {
+  const supabase = createServiceClient();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (supabase as any)
+    .from('businesses')
+    .select(
+      `
+      id,
+      name,
+      slug,
+      description,
+      logo_url,
+      business_type,
+      address,
+      city,
+      phone,
+      points_per_purchase,
+      pesos_per_point,
+      subscription_status
+    `,
+    )
+    .eq('join_code', joinCode.toUpperCase())
+    .in('subscription_status', ['active', 'trialing', 'free_forever'])
     .single();
 
   if (error || !data) {

--- a/apps/web/lib/services/verification.service.ts
+++ b/apps/web/lib/services/verification.service.ts
@@ -1,0 +1,181 @@
+// apps/web/lib/services/verification.service.ts
+
+import { createServiceClient } from '@/lib/supabase-server';
+import { sendVerificationEmail } from '@/lib/email';
+
+// ============================================
+// TYPES
+// ============================================
+
+interface SendVerificationResult {
+  success: boolean;
+  error?: string;
+}
+
+interface VerifyCodeResult {
+  success: boolean;
+  verificationId?: string;
+  purpose?: string;
+  error?: string;
+  attemptsRemaining?: number;
+}
+
+// ============================================
+// CONSTANTS
+// ============================================
+
+const CODE_LENGTH = 6;
+const CODE_EXPIRY_MINUTES = 10;
+const MAX_CODES_PER_HOUR = 3;
+
+// ============================================
+// HELPERS
+// ============================================
+
+function generateOTPCode(): string {
+  const digits = '0123456789';
+  let code = '';
+  for (let i = 0; i < CODE_LENGTH; i++) {
+    code += digits[Math.floor(Math.random() * digits.length)];
+  }
+  return code;
+}
+
+// ============================================
+// SEND EMAIL VERIFICATION
+// ============================================
+
+export async function sendEmailVerification(
+  email: string,
+  businessId: string,
+  businessName: string,
+  purpose: string = 'signup'
+): Promise<SendVerificationResult> {
+  const supabase = createServiceClient();
+  const normalizedEmail = email.toLowerCase().trim();
+
+  // Rate limit via existing RPC
+  const { data: rateLimitOk } = await supabase.rpc('check_rate_limit', {
+    p_identifier: normalizedEmail,
+    p_identifier_type: 'email',
+    p_action: 'verification_code',
+    p_max_requests: MAX_CODES_PER_HOUR,
+    p_window_seconds: 3600,
+  });
+
+  if (rateLimitOk === false) {
+    return {
+      success: false,
+      error: 'Too many verification attempts. Please try again in an hour.',
+    };
+  }
+
+  // Generate code and store
+  const code = generateOTPCode();
+  const expiresAt = new Date(Date.now() + CODE_EXPIRY_MINUTES * 60 * 1000).toISOString();
+
+  // Use `any` cast since verification_codes table isn't in generated types yet
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { error: insertError } = await (supabase as any)
+    .from('verification_codes')
+    .insert({
+      email: normalizedEmail,
+      code,
+      business_id: businessId,
+      purpose,
+      expires_at: expiresAt,
+      attempts: 0,
+      max_attempts: 5,
+    });
+
+  if (insertError) {
+    console.error('Failed to store verification code:', insertError);
+    return { success: false, error: 'Failed to send verification code.' };
+  }
+
+  // Send email
+  const emailResult = await sendVerificationEmail({
+    to: normalizedEmail,
+    code,
+    businessName,
+  });
+
+  if (!emailResult.success) {
+    return { success: false, error: 'Failed to send verification email.' };
+  }
+
+  return { success: true };
+}
+
+// ============================================
+// VERIFY CODE
+// ============================================
+
+export async function verifyCode(
+  code: string,
+  email: string,
+  businessId: string
+): Promise<VerifyCodeResult> {
+  const supabase = createServiceClient();
+
+  // Use `any` cast since verify_customer_otp RPC isn't in generated types yet
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data, error } = await (supabase as any).rpc('verify_customer_otp', {
+    p_code: code,
+    p_email: email.toLowerCase().trim(),
+    p_business_id: businessId,
+  });
+
+  if (error) {
+    console.error('Verify OTP RPC error:', error);
+    return { success: false, error: 'Verification failed. Please try again.' };
+  }
+
+  const result = data as {
+    success: boolean;
+    error?: string;
+    message?: string;
+    verification_id?: string;
+    purpose?: string;
+    attempts_remaining?: number;
+  };
+
+  if (!result.success) {
+    return {
+      success: false,
+      error: result.message || 'Invalid verification code.',
+      attemptsRemaining: result.attempts_remaining,
+    };
+  }
+
+  return {
+    success: true,
+    verificationId: result.verification_id,
+    purpose: result.purpose,
+  };
+}
+
+// ============================================
+// CHECK IF EMAIL HAS VERIFIED CODE
+// ============================================
+
+export async function hasVerifiedCode(
+  email: string,
+  businessId: string
+): Promise<boolean> {
+  const supabase = createServiceClient();
+
+  // Use `any` cast since verification_codes table isn't in generated types yet
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { data } = await (supabase as any)
+    .from('verification_codes')
+    .select('id')
+    .eq('email', email.toLowerCase().trim())
+    .eq('business_id', businessId)
+    .not('verified_at', 'is', null)
+    .gte('created_at', new Date(Date.now() - 30 * 60 * 1000).toISOString())
+    .limit(1)
+    .maybeSingle();
+
+  return !!data;
+}

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -25,6 +25,7 @@ const PUBLIC_PREFIXES = [
   '/api/',
   '/qr/',
   '/business/',
+  '/join/',
 ];
 
 function isPublicRoute(pathname: string): boolean {

--- a/packages/shared/types/database.ts
+++ b/packages/shared/types/database.ts
@@ -641,6 +641,7 @@ export type Database = {
           description: string | null
           id: string
           is_free_forever: boolean
+          join_code: string | null
           logo_url: string | null
           max_points_per_transaction: number | null
           min_purchase_for_points: number | null
@@ -666,6 +667,7 @@ export type Database = {
           description?: string | null
           id?: string
           is_free_forever?: boolean
+          join_code?: string | null
           logo_url?: string | null
           max_points_per_transaction?: number | null
           min_purchase_for_points?: number | null
@@ -691,6 +693,7 @@ export type Database = {
           description?: string | null
           id?: string
           is_free_forever?: boolean
+          join_code?: string | null
           logo_url?: string | null
           max_points_per_transaction?: number | null
           min_purchase_for_points?: number | null
@@ -769,6 +772,7 @@ export type Database = {
           email_sent_count: number | null
           full_name: string | null
           id: string
+          is_verified: boolean
           last_visit: string | null
           lifetime_points: number | null
           phone: string | null
@@ -776,6 +780,8 @@ export type Database = {
           tier: string | null
           total_points: number | null
           user_id: string | null
+          verification_method: string | null
+          verified_at: string | null
         }
         Insert: {
           age?: number | null
@@ -789,6 +795,7 @@ export type Database = {
           email_sent_count?: number | null
           full_name?: string | null
           id?: string
+          is_verified?: boolean
           last_visit?: string | null
           lifetime_points?: number | null
           phone?: string | null
@@ -796,6 +803,8 @@ export type Database = {
           tier?: string | null
           total_points?: number | null
           user_id?: string | null
+          verification_method?: string | null
+          verified_at?: string | null
         }
         Update: {
           age?: number | null
@@ -809,6 +818,7 @@ export type Database = {
           email_sent_count?: number | null
           full_name?: string | null
           id?: string
+          is_verified?: boolean
           last_visit?: string | null
           lifetime_points?: number | null
           phone?: string | null
@@ -816,6 +826,8 @@ export type Database = {
           tier?: string | null
           total_points?: number | null
           user_id?: string | null
+          verification_method?: string | null
+          verified_at?: string | null
         }
         Relationships: [
           {
@@ -1168,10 +1180,12 @@ export type Database = {
           id: string
           image_url: string | null
           is_active: boolean | null
+          low_stock_threshold: number
           name: string
           price_centavos: number
           sku: string | null
           sort_order: number | null
+          stock_quantity: number
           updated_at: string | null
         }
         Insert: {
@@ -1182,10 +1196,12 @@ export type Database = {
           id?: string
           image_url?: string | null
           is_active?: boolean | null
+          low_stock_threshold?: number
           name: string
           price_centavos: number
           sku?: string | null
           sort_order?: number | null
+          stock_quantity?: number
           updated_at?: string | null
         }
         Update: {
@@ -1196,10 +1212,12 @@ export type Database = {
           id?: string
           image_url?: string | null
           is_active?: boolean | null
+          low_stock_threshold?: number
           name?: string
           price_centavos?: number
           sku?: string | null
           sort_order?: number | null
+          stock_quantity?: number
           updated_at?: string | null
         }
         Relationships: [
@@ -2084,6 +2102,76 @@ export type Database = {
           },
         ]
       }
+      stock_movements: {
+        Row: {
+          business_id: string
+          created_at: string | null
+          id: string
+          movement_type: string
+          notes: string | null
+          performed_by: string | null
+          performer_name: string | null
+          product_id: string
+          quantity: number
+          reason: string | null
+          reference_id: string | null
+          stock_after: number
+          stock_before: number
+        }
+        Insert: {
+          business_id: string
+          created_at?: string | null
+          id?: string
+          movement_type: string
+          notes?: string | null
+          performed_by?: string | null
+          performer_name?: string | null
+          product_id: string
+          quantity: number
+          reason?: string | null
+          reference_id?: string | null
+          stock_after: number
+          stock_before: number
+        }
+        Update: {
+          business_id?: string
+          created_at?: string | null
+          id?: string
+          movement_type?: string
+          notes?: string | null
+          performed_by?: string | null
+          performer_name?: string | null
+          product_id?: string
+          quantity?: number
+          reason?: string | null
+          reference_id?: string | null
+          stock_after?: number
+          stock_before?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "stock_movements_business_id_fkey"
+            columns: ["business_id"]
+            isOneToOne: false
+            referencedRelation: "admin_business_stats"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "stock_movements_business_id_fkey"
+            columns: ["business_id"]
+            isOneToOne: false
+            referencedRelation: "businesses"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "stock_movements_product_id_fkey"
+            columns: ["product_id"]
+            isOneToOne: false
+            referencedRelation: "products"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       subscriptions: {
         Row: {
           billing_interval: string
@@ -2347,6 +2435,70 @@ export type Database = {
           },
         ]
       }
+      verification_codes: {
+        Row: {
+          attempts: number
+          business_id: string
+          code: string
+          created_at: string
+          customer_id: string | null
+          email: string
+          expires_at: string
+          id: string
+          max_attempts: number
+          purpose: string
+          verified_at: string | null
+        }
+        Insert: {
+          attempts?: number
+          business_id: string
+          code: string
+          created_at?: string
+          customer_id?: string | null
+          email: string
+          expires_at: string
+          id?: string
+          max_attempts?: number
+          purpose?: string
+          verified_at?: string | null
+        }
+        Update: {
+          attempts?: number
+          business_id?: string
+          code?: string
+          created_at?: string
+          customer_id?: string | null
+          email?: string
+          expires_at?: string
+          id?: string
+          max_attempts?: number
+          purpose?: string
+          verified_at?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "verification_codes_business_id_fkey"
+            columns: ["business_id"]
+            isOneToOne: false
+            referencedRelation: "admin_business_stats"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "verification_codes_business_id_fkey"
+            columns: ["business_id"]
+            isOneToOne: false
+            referencedRelation: "businesses"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "verification_codes_customer_id_fkey"
+            columns: ["customer_id"]
+            isOneToOne: false
+            referencedRelation: "customers"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
     }
     Views: {
       admin_business_stats: {
@@ -2427,6 +2579,7 @@ export type Database = {
         Args: { p_business_id: string; p_limit_type: string }
         Returns: boolean
       }
+      cleanup_expired_verification_codes: { Args: never; Returns: number }
       complete_redemption: {
         Args: { p_completed_by: string; p_redemption_id: string }
         Returns: Json
@@ -2573,6 +2726,10 @@ export type Database = {
       update_usage_counts: {
         Args: { p_business_id: string }
         Returns: undefined
+      }
+      verify_customer_otp: {
+        Args: { p_business_id: string; p_code: string; p_email: string }
+        Returns: Json
       }
       verify_redemption_code: {
         Args: { p_business_id: string; p_code: string }

--- a/supabase/migrations/20260221000000_customer_verification.sql
+++ b/supabase/migrations/20260221000000_customer_verification.sql
@@ -1,0 +1,76 @@
+-- ============================================
+-- Customer Verification & Business Join Codes
+-- ============================================
+
+-- 1. Add verification columns to customers
+ALTER TABLE customers
+  ADD COLUMN IF NOT EXISTS is_verified BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS verified_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS verification_method TEXT;
+
+-- 2. Backfill existing customers as verified
+UPDATE customers
+SET
+  is_verified = true,
+  verified_at = COALESCE(created_at, NOW()),
+  verification_method = CASE
+    WHEN user_id IS NOT NULL THEN 'oauth'
+    ELSE 'legacy'
+  END
+WHERE is_verified = false;
+
+-- 3. Add join_code to businesses
+ALTER TABLE businesses
+  ADD COLUMN IF NOT EXISTS join_code TEXT UNIQUE;
+
+-- 4. Auto-generate join codes for all existing businesses
+UPDATE businesses
+SET join_code = UPPER(SUBSTR(MD5(RANDOM()::TEXT || id::TEXT), 1, 8))
+WHERE join_code IS NULL;
+
+-- 5. Create verification_codes table
+CREATE TABLE IF NOT EXISTS verification_codes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  email TEXT NOT NULL,
+  code TEXT NOT NULL,
+  business_id UUID NOT NULL REFERENCES businesses(id) ON DELETE CASCADE,
+  customer_id UUID REFERENCES customers(id) ON DELETE SET NULL,
+  purpose TEXT NOT NULL DEFAULT 'signup',
+  attempts INTEGER NOT NULL DEFAULT 0,
+  max_attempts INTEGER NOT NULL DEFAULT 5,
+  expires_at TIMESTAMPTZ NOT NULL,
+  verified_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Index for lookups
+CREATE INDEX IF NOT EXISTS idx_verification_codes_email_business
+  ON verification_codes (email, business_id)
+  WHERE verified_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_verification_codes_expires
+  ON verification_codes (expires_at)
+  WHERE verified_at IS NULL;
+
+-- 6. RLS: service-role only access on verification_codes
+ALTER TABLE verification_codes ENABLE ROW LEVEL SECURITY;
+
+-- No RLS policies = only service role can access
+
+-- 7. Cleanup function for expired codes
+CREATE OR REPLACE FUNCTION public.cleanup_expired_verification_codes()
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  deleted_count INTEGER;
+BEGIN
+  DELETE FROM verification_codes
+  WHERE expires_at < NOW() - INTERVAL '1 hour'
+  RETURNING 1 INTO deleted_count;
+
+  RETURN COALESCE(deleted_count, 0);
+END;
+$$;

--- a/supabase/migrations/20260221100000_verify_customer_rpc.sql
+++ b/supabase/migrations/20260221100000_verify_customer_rpc.sql
@@ -1,0 +1,75 @@
+-- ============================================
+-- RPC: verify_customer_otp
+-- Validates a verification code, increments attempts,
+-- and marks the customer as verified on success.
+-- ============================================
+
+CREATE OR REPLACE FUNCTION public.verify_customer_otp(
+  p_code TEXT,
+  p_email TEXT,
+  p_business_id UUID
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_record verification_codes%ROWTYPE;
+  v_result JSONB;
+BEGIN
+  -- Find the most recent unexpired, unverified code for this email + business
+  SELECT * INTO v_record
+  FROM verification_codes
+  WHERE email = LOWER(TRIM(p_email))
+    AND business_id = p_business_id
+    AND verified_at IS NULL
+    AND expires_at > NOW()
+  ORDER BY created_at DESC
+  LIMIT 1;
+
+  -- No code found
+  IF v_record IS NULL THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'no_code_found',
+      'message', 'No verification code found. Please request a new one.'
+    );
+  END IF;
+
+  -- Max attempts exceeded
+  IF v_record.attempts >= v_record.max_attempts THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'max_attempts',
+      'message', 'Too many attempts. Please request a new code.'
+    );
+  END IF;
+
+  -- Increment attempts
+  UPDATE verification_codes
+  SET attempts = attempts + 1
+  WHERE id = v_record.id;
+
+  -- Check code
+  IF v_record.code != p_code THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'invalid_code',
+      'message', 'Invalid verification code. Please try again.',
+      'attempts_remaining', v_record.max_attempts - v_record.attempts - 1
+    );
+  END IF;
+
+  -- Code is correct — mark as verified
+  UPDATE verification_codes
+  SET verified_at = NOW()
+  WHERE id = v_record.id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'verification_id', v_record.id,
+    'purpose', v_record.purpose
+  );
+END;
+$$;


### PR DESCRIPTION
Replace phone-based customer signup with email verification. Add /join/[code] invite page, verification service, join-code dashboard settings, and fix subscription_status filter to include free_forever businesses.

Closes #18 