### PR TITLE
fix: customer invite link validation, phone inputs, and error handling & input restriction for phone number field

### DIFF
--- a/apps/web/app/api/billing/EmbeddedCheckout.tsx
+++ b/apps/web/app/api/billing/EmbeddedCheckout.tsx
@@ -531,10 +531,16 @@ export function EmbeddedCheckout({
               </label>
               <input
                 type="tel"
+                inputMode="numeric"
+                maxLength={11}
                 value={formData.phone}
-                onChange={(e) => handleInputChange('phone', e.target.value)}
+                onChange={(e) => handleInputChange('phone', e.target.value.replace(/\D/g, ''))}
+                onKeyDown={(e) => {
+                  if (['Backspace', 'Delete', 'Tab', 'Escape', 'Enter', 'ArrowLeft', 'ArrowRight'].includes(e.key)) return;
+                  if (!/^\d$/.test(e.key)) e.preventDefault();
+                }}
                 onBlur={() => handleBlur('phone')}
-                placeholder="+63 917 123 4567"
+                placeholder="09171234567"
                 className={`w-full px-4 py-3 rounded-lg bg-[#0d0d1a] border ${
                   getFieldError('phone')
                     ? 'border-red-500'

--- a/apps/web/app/api/dashboard/pos/products/route.ts
+++ b/apps/web/app/api/dashboard/pos/products/route.ts
@@ -76,8 +76,6 @@ export async function GET(request: NextRequest) {
 
     return NextResponse.json({ products });
   } catch (error) {
-    console.error('GET /api/dashboard/pos/products error:', error);
-
     if (error instanceof Error && 'code' in error) {
       const err = error as Error & { code: string };
       if (err.code === 'MODULE_NOT_AVAILABLE') {
@@ -88,6 +86,7 @@ export async function GET(request: NextRequest) {
       }
     }
 
+    console.error('GET /api/dashboard/pos/products error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }

--- a/apps/web/app/api/staff/customer/route.ts
+++ b/apps/web/app/api/staff/customer/route.ts
@@ -207,7 +207,9 @@ export async function POST(request: NextRequest) {
     const joinCode = staffInfo.business.join_code;
 
     if (joinCode) {
-      const baseUrl = request.nextUrl.origin;
+      const protocol = request.headers.get('x-forwarded-proto') || 'http';
+      const host = request.headers.get('host') || request.nextUrl.host;
+      const baseUrl = `${protocol}://${host}`;
       const joinUrl = `${baseUrl}/join/${joinCode}?email=${encodeURIComponent(email)}`;
 
       // Store verification code with purpose 'staff_invite'

--- a/apps/web/app/business/[slug]/my-bookings/my-bookings-client.tsx
+++ b/apps/web/app/business/[slug]/my-bookings/my-bookings-client.tsx
@@ -290,8 +290,15 @@ export function MyBookingsClient({ business }: MyBookingsClientProps) {
                   <div className="flex gap-3">
                     <Input
                       id="phone"
+                      type="tel"
+                      inputMode="numeric"
+                      maxLength={11}
                       placeholder="09171234567"
                       {...register('phone')}
+                      onKeyDown={(e) => {
+                        if (['Backspace', 'Delete', 'Tab', 'Escape', 'Enter', 'ArrowLeft', 'ArrowRight'].includes(e.key)) return;
+                        if (!/^\d$/.test(e.key)) e.preventDefault();
+                      }}
                       className={`flex-1 rounded-xl ${errors.phone ? 'border-destructive' : ''}`}
                     />
                     <Button

--- a/apps/web/app/dashboard/settings/page.tsx
+++ b/apps/web/app/dashboard/settings/page.tsx
@@ -564,13 +564,19 @@ export default function SettingsPage() {
                     </span>
                     <input
                       type="tel"
+                      inputMode="numeric"
+                      maxLength={10}
                       value={profile.phone}
                       onChange={(e) =>
                         setProfile((prev) => ({
                           ...prev,
-                          phone: e.target.value,
+                          phone: e.target.value.replace(/\D/g, ''),
                         }))
                       }
+                      onKeyDown={(e) => {
+                        if (['Backspace', 'Delete', 'Tab', 'Escape', 'Enter', 'ArrowLeft', 'ArrowRight'].includes(e.key)) return;
+                        if (!/^\d$/.test(e.key)) e.preventDefault();
+                      }}
                       className="flex-1 px-4 py-2.5 border border-gray-200 rounded-r-xl focus:ring-2 focus:ring-primary/20 focus:border-primary transition bg-background"
                       placeholder="9123456789"
                     />

--- a/apps/web/app/join/[code]/join-already-member.tsx
+++ b/apps/web/app/join/[code]/join-already-member.tsx
@@ -1,0 +1,50 @@
+// apps/web/app/join/[code]/join-already-member.tsx
+
+import Link from 'next/link';
+import { CheckCircle, Home } from 'lucide-react';
+
+interface JoinAlreadyMemberProps {
+  businessName: string;
+}
+
+export function JoinAlreadyMember({ businessName }: JoinAlreadyMemberProps) {
+  return (
+    <div className="min-h-screen bg-gray-50 flex flex-col">
+      <div className="bg-[#7F0404] py-6 px-4 text-center">
+        <h1 className="text-2xl font-bold text-white">{businessName}</h1>
+        <p className="text-white/80 text-sm">Loyalty Rewards Program</p>
+      </div>
+
+      <main className="flex-1 flex items-center justify-center px-4">
+        <div className="text-center max-w-md">
+          <div className="mx-auto flex h-20 w-20 items-center justify-center rounded-full bg-green-100 mb-6">
+            <CheckCircle className="h-10 w-10 text-green-600" />
+          </div>
+
+          <h2 className="text-2xl font-bold text-gray-900 mb-2">
+            You&apos;re Already a Member
+          </h2>
+
+          <p className="text-gray-500 mb-8">
+            You&apos;ve already joined <strong>{businessName}</strong>&apos;s
+            loyalty program. This invitation link has already been used.
+          </p>
+
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-primary-foreground rounded-xl font-semibold hover:bg-primary/90 transition-colors"
+          >
+            <Home className="h-4 w-4" />
+            Back to Homepage
+          </Link>
+        </div>
+      </main>
+
+      <footer className="py-4 text-center">
+        <p className="text-xs text-gray-400">
+          Powered by <span className="font-semibold text-gray-500">NoxaLoyalty</span>
+        </p>
+      </footer>
+    </div>
+  );
+}

--- a/apps/web/app/join/[code]/join-not-found.tsx
+++ b/apps/web/app/join/[code]/join-not-found.tsx
@@ -1,0 +1,45 @@
+// apps/web/app/join/[code]/join-not-found.tsx
+
+import Link from 'next/link';
+import { FileQuestion, Home } from 'lucide-react';
+
+export function JoinNotFound() {
+  return (
+    <div className="min-h-screen bg-gray-50 flex flex-col">
+      <div className="bg-[#7F0404] py-6 px-4 text-center">
+        <h1 className="text-2xl font-bold text-white">NoxaLoyalty</h1>
+      </div>
+
+      <main className="flex-1 flex items-center justify-center px-4">
+        <div className="text-center max-w-md">
+          <div className="mx-auto flex h-20 w-20 items-center justify-center rounded-full bg-gray-100 mb-6">
+            <FileQuestion className="h-10 w-10 text-gray-500" />
+          </div>
+
+          <h2 className="text-2xl font-bold text-gray-900 mb-2">
+            Invalid Join Link
+          </h2>
+
+          <p className="text-gray-500 mb-8">
+            This loyalty program link is invalid or has expired. Please check
+            with the business for a valid link.
+          </p>
+
+          <Link
+            href="/"
+            className="inline-flex items-center gap-2 px-6 py-3 bg-primary text-primary-foreground rounded-xl font-semibold hover:bg-primary/90 transition-colors"
+          >
+            <Home className="h-4 w-4" />
+            Back to Homepage
+          </Link>
+        </div>
+      </main>
+
+      <footer className="py-4 text-center">
+        <p className="text-xs text-gray-400">
+          Powered by <span className="font-semibold text-gray-500">NoxaLoyalty</span>
+        </p>
+      </footer>
+    </div>
+  );
+}

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -69,7 +69,7 @@ export default function NotFound() {
       {/* Footer */}
       <footer className="border-t border-gray-200 py-6">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <p className="text-center text-sm text-gray-500">
+          <p className="text-center text-sm text-gray-500" suppressHydrationWarning>
             &copy; {new Date().getFullYear()} NoxaLoyalty. All rights reserved.
           </p>
         </div>

--- a/apps/web/components/billing/EmbeddedCheckout.tsx
+++ b/apps/web/components/billing/EmbeddedCheckout.tsx
@@ -531,10 +531,16 @@ export function EmbeddedCheckout({
               </label>
               <input
                 type="tel"
+                inputMode="numeric"
+                maxLength={11}
                 value={formData.phone}
-                onChange={(e) => handleInputChange('phone', e.target.value)}
+                onChange={(e) => handleInputChange('phone', e.target.value.replace(/\D/g, ''))}
+                onKeyDown={(e) => {
+                  if (['Backspace', 'Delete', 'Tab', 'Escape', 'Enter', 'ArrowLeft', 'ArrowRight'].includes(e.key)) return;
+                  if (!/^\d$/.test(e.key)) e.preventDefault();
+                }}
                 onBlur={() => handleBlur('phone')}
-                placeholder="+63 917 123 4567"
+                placeholder="09171234567"
                 className={`w-full px-4 py-3 rounded-lg bg-[#0d0d1a] border ${
                   getFieldError('phone')
                     ? 'border-red-500'

--- a/apps/web/components/booking/BookingForm.tsx
+++ b/apps/web/components/booking/BookingForm.tsx
@@ -194,11 +194,16 @@ export function BookingForm({
             <Input
               id="phone"
               type="tel"
+              inputMode="numeric"
               placeholder="09171234567"
               value={phone}
               onChange={(e) => onPhoneChange(e.target.value.replace(/\D/g, ''))}
+              onKeyDown={(e) => {
+                if (['Backspace', 'Delete', 'Tab', 'Escape', 'Enter', 'ArrowLeft', 'ArrowRight'].includes(e.key)) return;
+                if (!/^\d$/.test(e.key)) e.preventDefault();
+              }}
               className={inputClasses}
-              maxLength={15}
+              maxLength={11}
               disabled={disabled}
             />
           </div>

--- a/apps/web/components/booking/create-booking-modal.tsx
+++ b/apps/web/components/booking/create-booking-modal.tsx
@@ -471,13 +471,20 @@ export function CreateBookingModal({
                   <Label htmlFor="customer_phone">Phone *</Label>
                   <Input
                     id="customer_phone"
+                    type="tel"
+                    inputMode="numeric"
+                    maxLength={11}
                     value={formData.customer_phone}
                     onChange={(e) =>
                       setFormData((prev) => ({
                         ...prev,
-                        customer_phone: e.target.value,
+                        customer_phone: e.target.value.replace(/\D/g, ''),
                       }))
                     }
+                    onKeyDown={(e) => {
+                      if (['Backspace', 'Delete', 'Tab', 'Escape', 'Enter', 'ArrowLeft', 'ArrowRight'].includes(e.key)) return;
+                      if (!/^\d$/.test(e.key)) e.preventDefault();
+                    }}
                     placeholder="e.g., 09171234567"
                   />
                 </div>

--- a/apps/web/components/pos/CustomerSearch.tsx
+++ b/apps/web/components/pos/CustomerSearch.tsx
@@ -43,12 +43,6 @@ export function CustomerSearch({ onCustomerFound, disabled }: CustomerSearchProp
     }
   }, [phone, onCustomerFound]);
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') {
-      handleSearch();
-    }
-  };
-
   return (
     <div className="space-y-2">
       <div className="flex gap-2">
@@ -56,13 +50,22 @@ export function CustomerSearch({ onCustomerFound, disabled }: CustomerSearchProp
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
           <Input
             type="tel"
+            inputMode="numeric"
+            maxLength={11}
             placeholder="Search by phone number..."
             value={phone}
             onChange={(e) => {
-              setPhone(e.target.value);
+              setPhone(e.target.value.replace(/\D/g, ''));
               setError(null);
             }}
-            onKeyDown={handleKeyDown}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                handleSearch();
+                return;
+              }
+              if (['Backspace', 'Delete', 'Tab', 'Escape', 'ArrowLeft', 'ArrowRight'].includes(e.key)) return;
+              if (!/^\d$/.test(e.key)) e.preventDefault();
+            }}
             className="pl-9"
             disabled={disabled || isSearching}
           />

--- a/apps/web/lib/services/public-business.service.ts
+++ b/apps/web/lib/services/public-business.service.ts
@@ -112,8 +112,8 @@ export async function getBusinessBySlug(
     `
     )
     .eq('slug', slug)
-    .in('subscription_status', ['active', 'trialing', 'free_forever'])
-    .single();
+    .in('subscription_status', ['active', 'trialing', 'free_forever', 'preview'])
+    .maybeSingle();
 
   if (error || !data) {
     return null;
@@ -163,10 +163,13 @@ export async function getBusinessByJoinCode(
     `,
     )
     .eq('join_code', joinCode.toUpperCase())
-    .in('subscription_status', ['active', 'trialing', 'free_forever'])
-    .single();
+    .in('subscription_status', ['active', 'trialing', 'free_forever', 'preview'])
+    .maybeSingle();
 
   if (error || !data) {
+    if (error) {
+      console.error('getBusinessByJoinCode error:', error.message, { joinCode });
+    }
     return null;
   }
 


### PR DESCRIPTION
- Fix join page showing 404 by adding 'preview' to subscription_status filter
- Replace notFound() with inline components to avoid Next.js Performance API error
- Make staff invitation links one-time use (check if customer already exists)
- Add digit-only validation to all phone input fields across the app
- Suppress expected POS module 403 error from server console logs
- Use .maybeSingle() instead of .single() to prevent PostgREST errors on 0 rows

Closes #22 