### PR TITLE
feat: require first purchase before awarding referral points

### DIFF
--- a/apps/mobile/app/referral.tsx
+++ b/apps/mobile/app/referral.tsx
@@ -85,10 +85,10 @@ export default function ReferralScreen() {
           style={styles.heroCard}
         >
           <Text style={styles.heroEmoji}>🎁</Text>
-          <Text style={styles.heroTitle}>Give 25, Get 25</Text>
+          <Text style={styles.heroTitle}>Give Points, Get Points</Text>
           <Text style={styles.heroSubtitle}>
-            Share your code with friends. When they join, you both earn 25 bonus
-            points!
+            Share your code with friends. When they make their first purchase,
+            you both earn bonus points!
           </Text>
         </LinearGradient>
 
@@ -108,6 +108,15 @@ export default function ReferralScreen() {
               <Text style={styles.stepEmoji}>👋</Text>
             </View>
             <Text style={styles.stepLabel}>Friend Joins</Text>
+          </View>
+
+          <View style={styles.stepConnector} />
+
+          <View style={styles.stepItem}>
+            <View style={styles.stepCircle}>
+              <Text style={styles.stepEmoji}>🛒</Text>
+            </View>
+            <Text style={styles.stepLabel}>Friend Buys</Text>
           </View>
 
           <View style={styles.stepConnector} />
@@ -269,9 +278,15 @@ export default function ReferralScreen() {
                       {new Date(item.completed_at).toLocaleDateString()}
                     </Text>
                   </View>
-                  <View style={styles.pointsBadge}>
-                    <Text style={styles.pointsBadgeText}>
-                      +{item.referrer_points} pts
+                  <View style={[
+                    styles.pointsBadge,
+                    item.status === 'pending' && styles.pendingBadge,
+                  ]}>
+                    <Text style={[
+                      styles.pointsBadgeText,
+                      item.status === 'pending' && styles.pendingBadgeText,
+                    ]}>
+                      {item.status === 'pending' ? 'Pending' : `+${item.referrer_points} pts`}
                     </Text>
                   </View>
                 </View>
@@ -595,5 +610,11 @@ const styles = StyleSheet.create({
     fontSize: FONT_SIZE.sm,
     fontWeight: FONT_WEIGHT.bold,
     color: COLORS.success,
+  },
+  pendingBadge: {
+    backgroundColor: COLORS.gray[200],
+  },
+  pendingBadgeText: {
+    color: COLORS.gray[500],
   },
 });

--- a/apps/mobile/src/components/ReferralOnboardingModal.tsx
+++ b/apps/mobile/src/components/ReferralOnboardingModal.tsx
@@ -273,9 +273,13 @@ export function ReferralOnboardingModal() {
               <View style={styles.successCircle}>
                 <Text style={styles.successCheckmark}>✓</Text>
               </View>
-              <Text style={styles.heading}>Welcome Bonus Earned!</Text>
+              <Text style={styles.heading}>
+                {success.pending ? 'Referral Code Saved!' : 'Welcome Bonus Earned!'}
+              </Text>
               <Text style={styles.subtitle}>
-                +{success.pointsEarned} points at {success.businessName}
+                {success.pending
+                  ? `You'll earn +${success.pointsEarned} points at ${success.businessName} after your first purchase`
+                  : `+${success.pointsEarned} points at ${success.businessName}`}
               </Text>
               <TouchableOpacity
                 style={styles.primaryButton}

--- a/apps/mobile/src/hooks/useRedeemReferral.ts
+++ b/apps/mobile/src/hooks/useRedeemReferral.ts
@@ -22,6 +22,7 @@ interface SuccessInfo {
   businessName: string;
   pointsEarned: number;
   businessId: string;
+  pending: boolean;
 }
 
 // ============================================
@@ -102,12 +103,15 @@ export function useRedeemReferral() {
         return;
       }
 
-      await refreshCustomer();
+      if (!result.pending) {
+        await refreshCustomer();
+      }
 
       setSuccess({
-        businessName: preview.businessName,
+        businessName: result.business_name || preview.businessName,
         pointsEarned: result.invitee_points || preview.bonusPoints,
         businessId: result.business_id || '',
+        pending: result.pending ?? false,
       });
       setStep('success');
     } catch (err) {

--- a/apps/mobile/src/hooks/useReferral.ts
+++ b/apps/mobile/src/hooks/useReferral.ts
@@ -21,6 +21,7 @@ interface ReferralHistoryItem {
   referrer_points: number;
   invitee_points: number;
   completed_at: string;
+  status: 'pending' | 'completed';
   invitee: { full_name: string | null } | null;
   business: { name: string; logo_url: string | null } | null;
 }

--- a/apps/mobile/src/services/referral.service.ts
+++ b/apps/mobile/src/services/referral.service.ts
@@ -12,6 +12,7 @@ interface ReferralCompletion {
   referrer_points: number;
   invitee_points: number;
   completed_at: string;
+  status: 'pending' | 'completed';
   invitee: {
     full_name: string | null;
   } | null;
@@ -42,9 +43,11 @@ export interface ReferralCodePreview {
 export interface RedeemReferralResult {
   success: boolean;
   error?: string;
+  pending?: boolean;
   referrer_points?: number;
   invitee_points?: number;
   business_id?: string;
+  business_name?: string;
 }
 
 // ============================================
@@ -87,6 +90,7 @@ export const referralService = {
         referrer_points,
         invitee_points,
         completed_at,
+        status,
         invitee:customers!referral_completions_invitee_customer_id_fkey (full_name),
         business:businesses!referral_completions_business_id_fkey (name, logo_url)
       `)
@@ -167,7 +171,7 @@ export const referralService = {
     code: string,
     inviteeCustomerId: string,
   ): Promise<RedeemReferralResult> {
-    const { data, error } = await supabase.rpc('complete_referral', {
+    const { data, error } = await supabase.rpc('claim_referral_code', {
       p_referral_code: code.toUpperCase().trim(),
       p_invitee_customer_id: inviteeCustomerId,
     });

--- a/packages/shared/types/database.ts
+++ b/packages/shared/types/database.ts
@@ -994,6 +994,64 @@ export type Database = {
           },
         ]
       }
+      notifications: {
+        Row: {
+          body: string
+          business_id: string
+          created_at: string
+          customer_id: string
+          data: Json | null
+          id: string
+          is_read: boolean
+          title: string
+          type: string
+        }
+        Insert: {
+          body: string
+          business_id: string
+          created_at?: string
+          customer_id: string
+          data?: Json | null
+          id?: string
+          is_read?: boolean
+          title: string
+          type?: string
+        }
+        Update: {
+          body?: string
+          business_id?: string
+          created_at?: string
+          customer_id?: string
+          data?: Json | null
+          id?: string
+          is_read?: boolean
+          title?: string
+          type?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "notifications_business_id_fkey"
+            columns: ["business_id"]
+            isOneToOne: false
+            referencedRelation: "admin_business_stats"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "notifications_business_id_fkey"
+            columns: ["business_id"]
+            isOneToOne: false
+            referencedRelation: "businesses"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "notifications_customer_id_fkey"
+            columns: ["customer_id"]
+            isOneToOne: false
+            referencedRelation: "customers"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       payment_history: {
         Row: {
           amount: number
@@ -1240,6 +1298,41 @@ export type Database = {
           },
         ]
       }
+      push_tokens: {
+        Row: {
+          created_at: string
+          customer_id: string
+          id: string
+          platform: string
+          token: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          customer_id: string
+          id?: string
+          platform?: string
+          token: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          customer_id?: string
+          id?: string
+          platform?: string
+          token?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "push_tokens_customer_id_fkey"
+            columns: ["customer_id"]
+            isOneToOne: false
+            referencedRelation: "customers"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       rate_limits: {
         Row: {
           action: string
@@ -1403,6 +1496,7 @@ export type Database = {
           referral_code_id: string
           referrer_customer_id: string
           referrer_points: number
+          status: string
         }
         Insert: {
           business_id: string
@@ -1413,6 +1507,7 @@ export type Database = {
           referral_code_id: string
           referrer_customer_id: string
           referrer_points: number
+          status?: string
         }
         Update: {
           business_id?: string
@@ -1423,6 +1518,7 @@ export type Database = {
           referral_code_id?: string
           referrer_customer_id?: string
           referrer_points?: number
+          status?: string
         }
         Relationships: [
           {
@@ -2706,6 +2802,10 @@ export type Database = {
         Args: { p_business_id: string; p_limit_type: string }
         Returns: boolean
       }
+      claim_referral_code: {
+        Args: { p_invitee_customer_id: string; p_referral_code: string }
+        Returns: Json
+      }
       cleanup_expired_verification_codes: { Args: never; Returns: number }
       complete_redemption: {
         Args: { p_completed_by: string; p_redemption_id: string }
@@ -2837,21 +2937,6 @@ export type Database = {
           user_id: string
         }[]
       }
-      resolve_customer_for_business: {
-        Args: { p_scanned_code: string; p_business_id: string }
-        Returns: {
-          card_token: string
-          created_by_business_id: string
-          email: string
-          full_name: string
-          id: string
-          lifetime_points: number
-          qr_code_url: string
-          tier: string
-          total_points: number
-          user_id: string
-        }[]
-      }
       recalculate_usage_counts: {
         Args: { p_business_id: string }
         Returns: undefined
@@ -2868,6 +2953,21 @@ export type Database = {
       redeem_reward: {
         Args: { p_customer_id: string; p_reward_id: string }
         Returns: Json
+      }
+      resolve_customer_for_business: {
+        Args: { p_business_id: string; p_scanned_code: string }
+        Returns: {
+          card_token: string
+          created_by_business_id: string
+          email: string
+          full_name: string
+          id: string
+          lifetime_points: number
+          qr_code_url: string
+          tier: string
+          total_points: number
+          user_id: string
+        }[]
       }
       update_staff_last_login: {
         Args: { p_staff_id: string }

--- a/supabase/migrations/20260225_referral_first_purchase.sql
+++ b/supabase/migrations/20260225_referral_first_purchase.sql
@@ -1,0 +1,160 @@
+-- Migration: Require first purchase before referral points are awarded
+-- Instead of awarding referral points immediately, save as "pending" and
+-- complete when the invitee makes their first purchase at the business.
+
+-- ============================================
+-- 1a. Add status column to referral_completions
+-- ============================================
+
+ALTER TABLE "public"."referral_completions"
+  ADD COLUMN IF NOT EXISTS "status" TEXT NOT NULL DEFAULT 'pending';
+
+-- Backfill existing rows — they already received points
+UPDATE "public"."referral_completions"
+  SET "status" = 'completed'
+  WHERE "status" = 'pending';
+
+-- ============================================
+-- 1b. Create claim_referral_code function
+-- ============================================
+-- Called by mobile app during onboarding. Saves the referral as pending
+-- without awarding any points. Points are awarded later via trigger
+-- when the invitee makes their first purchase.
+
+CREATE OR REPLACE FUNCTION "public"."claim_referral_code"(
+  "p_referral_code" TEXT,
+  "p_invitee_customer_id" UUID
+) RETURNS JSONB
+LANGUAGE "plpgsql" SECURITY DEFINER
+SET "search_path" TO 'public'
+AS $$
+DECLARE
+  v_ref referral_codes%ROWTYPE;
+  v_reward_points INT;
+  v_existing UUID;
+  v_business_name TEXT;
+BEGIN
+  -- 1. Look up the referral code
+  SELECT * INTO v_ref
+  FROM referral_codes
+  WHERE code = upper(p_referral_code) AND is_active = true;
+
+  IF v_ref IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Invalid or inactive referral code');
+  END IF;
+
+  -- 2. Self-referral check
+  IF v_ref.customer_id = p_invitee_customer_id THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Cannot use your own referral code');
+  END IF;
+
+  -- 3. Duplicate invitee check (one referral per invitee per business)
+  SELECT id INTO v_existing
+  FROM referral_completions
+  WHERE invitee_customer_id = p_invitee_customer_id AND business_id = v_ref.business_id;
+
+  IF v_existing IS NOT NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Already used a referral for this business');
+  END IF;
+
+  -- 4. Max uses check
+  IF v_ref.uses >= v_ref.max_uses THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Referral code has reached maximum uses');
+  END IF;
+
+  -- 5. Get reward points and business name
+  SELECT referral_reward_points, name INTO v_reward_points, v_business_name
+  FROM businesses
+  WHERE id = v_ref.business_id;
+
+  IF v_reward_points IS NULL OR v_reward_points <= 0 THEN
+    v_reward_points := 25;
+  END IF;
+
+  -- 6. Record completion as PENDING (no points awarded yet)
+  INSERT INTO referral_completions (
+    referral_code_id, referrer_customer_id, invitee_customer_id,
+    business_id, referrer_points, invitee_points, status
+  ) VALUES (
+    v_ref.id, v_ref.customer_id, p_invitee_customer_id,
+    v_ref.business_id, v_reward_points, v_reward_points, 'pending'
+  );
+
+  -- 7. Increment uses
+  UPDATE referral_codes SET uses = uses + 1 WHERE id = v_ref.id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'pending', true,
+    'referrer_points', v_reward_points,
+    'invitee_points', v_reward_points,
+    'business_id', v_ref.business_id,
+    'business_name', v_business_name
+  );
+END;
+$$;
+
+-- ============================================
+-- 1c. Trigger function: complete pending referrals on first purchase
+-- ============================================
+
+CREATE OR REPLACE FUNCTION "public"."trg_complete_pending_referrals"()
+RETURNS TRIGGER
+LANGUAGE "plpgsql" SECURITY DEFINER
+SET "search_path" TO 'public'
+AS $$
+DECLARE
+  v_pending RECORD;
+BEGIN
+  -- Only fire on real purchases (earn transactions with amount_spent)
+  IF NEW.type != 'earn' OR NEW.amount_spent IS NULL OR NEW.amount_spent <= 0 THEN
+    RETURN NEW;
+  END IF;
+
+  -- Find all pending referral completions for this customer + business
+  FOR v_pending IN
+    SELECT id, referrer_customer_id, invitee_customer_id,
+           business_id, referrer_points, invitee_points
+    FROM referral_completions
+    WHERE invitee_customer_id = NEW.customer_id
+      AND business_id = NEW.business_id
+      AND status = 'pending'
+  LOOP
+    -- Award points to referrer
+    INSERT INTO transactions (customer_id, business_id, type, points, description)
+    VALUES (v_pending.referrer_customer_id, v_pending.business_id, 'earn',
+            v_pending.referrer_points, 'Referral bonus - invited a friend');
+
+    UPDATE customers SET
+      total_points = total_points + v_pending.referrer_points,
+      lifetime_points = lifetime_points + v_pending.referrer_points
+    WHERE id = v_pending.referrer_customer_id;
+
+    -- Award points to invitee
+    INSERT INTO transactions (customer_id, business_id, type, points, description)
+    VALUES (v_pending.invitee_customer_id, v_pending.business_id, 'earn',
+            v_pending.invitee_points, 'Welcome bonus - joined via referral');
+
+    UPDATE customers SET
+      total_points = total_points + v_pending.invitee_points,
+      lifetime_points = lifetime_points + v_pending.invitee_points
+    WHERE id = v_pending.invitee_customer_id;
+
+    -- Mark referral as completed
+    UPDATE referral_completions
+    SET status = 'completed', completed_at = NOW()
+    WHERE id = v_pending.id;
+  END LOOP;
+
+  RETURN NEW;
+END;
+$$;
+
+-- ============================================
+-- 1d. Create trigger
+-- ============================================
+
+CREATE TRIGGER trg_complete_pending_referrals
+  AFTER INSERT ON "public"."transactions"
+  FOR EACH ROW
+  EXECUTE FUNCTION "public"."trg_complete_pending_referrals"();


### PR DESCRIPTION
Defer referral point awards until the invitee makes their first purchase at the business, preventing abuse from sign-up-only referral farming.

- Add status column to referral_completions (pending/completed)
- Create claim_referral_code SQL function (saves as pending, no points)
- Add trigger on transactions to complete pending referrals on first purchase
- Update mobile service to call claim_referral_code instead of complete_referral
- Update onboarding modal to show "Referral Code Saved!" pending message
- Update referral history screen with pending badge and 4-step flow
- Remove hardcoded "25" points from hero text (respects business settings)

Closes #55 