### PR TITLE
fix: return error when business has no join code and disable prefille…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Coding Rules
 
 - Never use `any` type for type declarations. Create type interfaces instead.
+- Never use `as any` type assertions. Use proper types or create appropriate interfaces.
 - Build only the minimum viable version of every feature.
 - Follow the anti-overengineering rules.
 

--- a/apps/web/app/api/staff/customer/route.ts
+++ b/apps/web/app/api/staff/customer/route.ts
@@ -206,32 +206,36 @@ export async function POST(request: NextRequest) {
     // 6. Send invite email
     const joinCode = staffInfo.business.join_code;
 
-    if (joinCode) {
-      const protocol = request.headers.get('x-forwarded-proto') || 'http';
-      const host = request.headers.get('host') || request.nextUrl.host;
-      const baseUrl = `${protocol}://${host}`;
-      const joinUrl = `${baseUrl}/join/${joinCode}?email=${encodeURIComponent(email)}`;
-
-      // Store verification code with purpose 'staff_invite'
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      await (serviceClient as any)
-        .from('verification_codes')
-        .insert({
-          email,
-          code: '000000', // placeholder — customer will go through full OTP flow
-          business_id: staffInfo.business.id,
-          purpose: 'staff_invite',
-          expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(), // 7 days
-          attempts: 0,
-          max_attempts: 5,
-        });
-
-      await sendCustomerInviteEmail({
-        to: email,
-        businessName: staffInfo.business.name,
-        joinUrl,
-      });
+    if (!joinCode) {
+      return NextResponse.json(
+        { error: 'Your business does not have a join code configured. Please generate one in Dashboard Settings before inviting customers.' },
+        { status: 400 },
+      );
     }
+
+    const protocol = request.headers.get('x-forwarded-proto') || 'http';
+    const host = request.headers.get('host') || request.nextUrl.host;
+    const baseUrl = `${protocol}://${host}`;
+    const joinUrl = `${baseUrl}/join/${joinCode}?email=${encodeURIComponent(email)}`;
+
+    // Store verification code with purpose 'staff_invite'
+    await serviceClient
+      .from('verification_codes')
+      .insert({
+        email,
+        code: '000000', // placeholder — customer will go through full OTP flow
+        business_id: staffInfo.business.id,
+        purpose: 'staff_invite',
+        expires_at: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(), // 7 days
+        attempts: 0,
+        max_attempts: 5,
+      });
+
+    await sendCustomerInviteEmail({
+      to: email,
+      businessName: staffInfo.business.name,
+      joinUrl,
+    });
 
     // 7. Log audit event
     await logAuditEvent(serviceClient, {
@@ -241,7 +245,7 @@ export async function POST(request: NextRequest) {
       details: {
         staffId: staffInfo.staffId,
         inviteEmail: email,
-        emailSent: !!joinCode,
+        emailSent: true,
         processingTimeMs: Date.now() - startTime,
         ipAddress,
       },
@@ -251,7 +255,7 @@ export async function POST(request: NextRequest) {
       success: true,
       data: {
         alreadyRegistered: false,
-        emailSent: !!joinCode,
+        emailSent: true,
       },
     });
   } catch (error) {

--- a/apps/web/app/join/[code]/join-page-client.tsx
+++ b/apps/web/app/join/[code]/join-page-client.tsx
@@ -350,8 +350,9 @@ export function JoinPageClient({
                     {...step1Form.register('email')}
                     type="email"
                     placeholder="juan@email.com"
-                    disabled={isSubmitting}
-                    className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-xl bg-white text-gray-900 placeholder:text-gray-400 focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors"
+                    disabled={isSubmitting || !!prefillEmail}
+                    readOnly={!!prefillEmail}
+                    className={`w-full pl-10 pr-4 py-3 border border-gray-300 rounded-xl text-gray-900 placeholder:text-gray-400 focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors ${prefillEmail ? 'bg-gray-100 cursor-not-allowed' : 'bg-white'}`}
                   />
                 </div>
                 {step1Form.formState.errors.email && (


### PR DESCRIPTION
…d email field

Previously, customer invitations silently failed when a business had no join_code configured — the API returned success but no email was sent. Now it returns a 400 error with a clear message. Also removed unnecessary `as any` cast and made the email field read-only when pre-filled from an invitation link to prevent mismatches.

Closes #61 