### PR TITLE
feat: switch card lookup from phone to email

### DIFF
--- a/apps/web/app/api/public/business/[slug]/lookup/route.ts
+++ b/apps/web/app/api/public/business/[slug]/lookup/route.ts
@@ -4,7 +4,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createServiceClient } from '@/lib/supabase-server';
 import {
   getBusinessBySlug,
-  getCustomerByPhone,
+  getCustomerByEmail,
   maskEmail,
 } from '@/lib/services/public-business.service';
 import { sendEmailVerification } from '@/lib/services/verification.service';
@@ -15,11 +15,8 @@ import type { Json } from '../../../../../../../../packages/shared/types/databas
 // VALIDATION SCHEMA
 // ============================================
 
-const PhoneLookupSchema = z.object({
-  phone: z
-    .string()
-    .length(11, 'Phone number must be exactly 11 digits')
-    .regex(/^\d+$/, 'Phone number must contain only digits'),
+const EmailLookupSchema = z.object({
+  email: z.string().email('Please enter a valid email address'),
 });
 
 // ============================================
@@ -125,7 +122,7 @@ export async function POST(
 
     // 3. Parse and validate input
     const body = await request.json();
-    const validation = PhoneLookupSchema.safeParse(body);
+    const validation = EmailLookupSchema.safeParse(body);
 
     if (!validation.success) {
       return NextResponse.json(
@@ -137,15 +134,15 @@ export async function POST(
       );
     }
 
-    const { phone } = validation.data;
+    const { email } = validation.data;
 
-    // 4. Look up customer by phone
-    const customer = await getCustomerByPhone(business.id, phone);
+    // 4. Look up customer by email
+    const customer = await getCustomerByEmail(business.id, email);
 
-    // 5. If customer found with email, send OTP
-    if (customer?.email) {
+    // 5. If customer found, send OTP to the provided email
+    if (customer) {
       const otpResult = await sendEmailVerification(
-        customer.email,
+        email,
         business.id,
         business.name,
         'card_lookup'
@@ -172,32 +169,30 @@ export async function POST(
 
       return NextResponse.json({
         success: true,
-        message: 'A verification code has been sent to your registered email.',
-        maskedEmail: maskEmail(customer.email),
+        message: 'A verification code has been sent to your email.',
+        maskedEmail: maskEmail(email),
       });
     }
 
-    // 6. Customer not found or no email — artificial delay + generic response
+    // 6. Customer not found — artificial delay + generic response
     await artificialDelay();
 
     await logAuditEvent(serviceClient, {
       action: 'card_lookup_not_found',
       businessId: business.id,
       details: {
-        phoneHash: phone.slice(-4),
         processingTimeMs: Date.now() - startTime,
         ipAddress,
         userAgent,
       },
     });
 
-    // Same shape as success to prevent enumeration
     return NextResponse.json({
       success: false,
-      message: 'No card found for this phone number. Please check the number or sign up first.',
+      message: 'No card found for this email address. Please check the email or sign up first.',
     });
   } catch (error) {
-    console.error('Phone lookup error:', error);
+    console.error('Email lookup error:', error);
     return NextResponse.json(
       { error: 'Something went wrong. Please try again.' },
       { status: 500 }

--- a/apps/web/app/api/public/business/[slug]/lookup/verify/route.ts
+++ b/apps/web/app/api/public/business/[slug]/lookup/verify/route.ts
@@ -4,7 +4,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createServiceClient } from '@/lib/supabase-server';
 import {
   getBusinessBySlug,
-  getCustomerByPhone,
+  getCustomerByEmail,
 } from '@/lib/services/public-business.service';
 import { verifyCode } from '@/lib/services/verification.service';
 import { z } from 'zod';
@@ -15,10 +15,7 @@ import type { Json } from '../../../../../../../../../packages/shared/types/data
 // ============================================
 
 const VerifySchema = z.object({
-  phone: z
-    .string()
-    .length(11, 'Phone number must be exactly 11 digits')
-    .regex(/^\d+$/, 'Phone number must contain only digits'),
+  email: z.string().email('Please enter a valid email address'),
   code: z
     .string()
     .length(6, 'Code must be 6 digits')
@@ -130,11 +127,11 @@ export async function POST(
       );
     }
 
-    const { phone, code } = validation.data;
+    const { email, code } = validation.data;
 
-    // 4. Look up customer to get email
-    const customer = await getCustomerByPhone(business.id, phone);
-    if (!customer?.email) {
+    // 4. Look up customer by email
+    const customer = await getCustomerByEmail(business.id, email);
+    if (!customer) {
       return NextResponse.json(
         { error: 'Verification failed. Please try looking up your card again.' },
         { status: 400 }
@@ -142,7 +139,7 @@ export async function POST(
     }
 
     // 5. Verify the OTP code
-    const verifyResult = await verifyCode(code, customer.email, business.id);
+    const verifyResult = await verifyCode(code, email, business.id);
 
     if (!verifyResult.success) {
       await logAuditEvent(serviceClient, {
@@ -182,6 +179,7 @@ export async function POST(
       success: true,
       data: {
         customerName: customer.fullName,
+        phone: customer.phone || null,
         qrCodeUrl: customer.qrCodeUrl,
         tier: customer.tier,
         totalPoints: customer.totalPoints,

--- a/apps/web/app/business/[slug]/card/card-modal.tsx
+++ b/apps/web/app/business/[slug]/card/card-modal.tsx
@@ -14,7 +14,7 @@ interface CardModalProps {
   onClose: () => void;
   customerName: string;
   businessName: string;
-  phone: string;
+  phone?: string;
   qrCodeUrl: string;
   tier: string;
   totalPoints: number;
@@ -224,9 +224,11 @@ export function CardModal({
                     <h3 className="text-sm sm:text-base font-bold text-gray-900 truncate">
                       {customerName}
                     </h3>
-                    <p className="text-xs text-gray-500">
-                      {formatPhone(phone)}
-                    </p>
+                    {phone && (
+                      <p className="text-xs text-gray-500">
+                        {formatPhone(phone)}
+                      </p>
+                    )}
                     <div className="flex items-center gap-1 mt-0.5">
                       <Star className="w-3.5 h-3.5 text-amber-500" />
                       <span className="text-xs font-semibold text-gray-700">

--- a/apps/web/app/business/[slug]/card/lookup-form.tsx
+++ b/apps/web/app/business/[slug]/card/lookup-form.tsx
@@ -13,11 +13,8 @@ import { CardModal } from './card-modal';
 // VALIDATION SCHEMAS
 // ============================================
 
-const PhoneLookupSchema = z.object({
-  phone: z
-    .string()
-    .length(11, 'Phone number must be exactly 11 digits')
-    .regex(/^\d+$/, 'Phone number must contain only digits'),
+const EmailLookupSchema = z.object({
+  email: z.string().email('Please enter a valid email address'),
 });
 
 const OtpSchema = z.object({
@@ -27,7 +24,7 @@ const OtpSchema = z.object({
     .regex(/^\d+$/, 'Code must contain only digits'),
 });
 
-type PhoneLookupInput = z.infer<typeof PhoneLookupSchema>;
+type EmailLookupInput = z.infer<typeof EmailLookupSchema>;
 type OtpInput = z.infer<typeof OtpSchema>;
 
 // ============================================
@@ -41,7 +38,7 @@ interface LookupFormProps {
 
 interface CardData {
   customerName: string;
-  phone: string;
+  phone: string | null;
   qrCodeUrl: string;
   tier: string;
   totalPoints: number;
@@ -59,12 +56,12 @@ export function LookupForm({ businessSlug, businessName }: LookupFormProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [cardData, setCardData] = useState<CardData | null>(null);
   const [maskedEmail, setMaskedEmail] = useState<string | null>(null);
-  const [phone, setPhone] = useState<string>('');
+  const [email, setEmail] = useState<string>('');
   const [resendCooldown, setResendCooldown] = useState(0);
 
-  const phoneForm = useForm<PhoneLookupInput>({
-    resolver: zodResolver(PhoneLookupSchema),
-    defaultValues: { phone: '' },
+  const emailForm = useForm<EmailLookupInput>({
+    resolver: zodResolver(EmailLookupSchema),
+    defaultValues: { email: '' },
   });
 
   const otpForm = useForm<OtpInput>({
@@ -76,7 +73,7 @@ export function LookupForm({ businessSlug, businessName }: LookupFormProps) {
   // STEP 1: Submit phone — send OTP
   // ============================================
 
-  const onPhoneSubmit = async (data: PhoneLookupInput) => {
+  const onEmailSubmit = async (data: EmailLookupInput) => {
     setIsSubmitting(true);
     setError(null);
 
@@ -95,13 +92,12 @@ export function LookupForm({ businessSlug, businessName }: LookupFormProps) {
       }
 
       if (!json.success) {
-        // Customer not found or no email
-        setError(json.message || 'No card found for this phone number.');
+        setError(json.message || 'No card found for this email address.');
         return;
       }
 
       // OTP sent successfully
-      setPhone(data.phone);
+      setEmail(data.email);
       setMaskedEmail(json.maskedEmail || null);
       setStep('otp_sent');
       startResendCooldown();
@@ -124,7 +120,7 @@ export function LookupForm({ businessSlug, businessName }: LookupFormProps) {
       const response = await fetch(`/api/public/business/${businessSlug}/lookup/verify`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ phone, code: data.code }),
+        body: JSON.stringify({ email, code: data.code }),
       });
 
       const json = await response.json();
@@ -143,7 +139,7 @@ export function LookupForm({ businessSlug, businessName }: LookupFormProps) {
       // Success — show card
       setCardData({
         customerName: json.data.customerName,
-        phone,
+        phone: json.data.phone || null,
         qrCodeUrl: json.data.qrCodeUrl,
         tier: json.data.tier,
         totalPoints: json.data.totalPoints,
@@ -168,7 +164,7 @@ export function LookupForm({ businessSlug, businessName }: LookupFormProps) {
       const response = await fetch(`/api/public/business/${businessSlug}/lookup`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ phone }),
+        body: JSON.stringify({ email }),
       });
 
       const json = await response.json();
@@ -218,8 +214,8 @@ export function LookupForm({ businessSlug, businessName }: LookupFormProps) {
     setStep('idle');
     setError(null);
     setMaskedEmail(null);
-    setPhone('');
-    phoneForm.reset();
+    setEmail('');
+    emailForm.reset();
     otpForm.reset();
   };
 
@@ -229,10 +225,10 @@ export function LookupForm({ businessSlug, businessName }: LookupFormProps) {
 
   return (
     <>
-      {/* STEP 1: Phone Input */}
+      {/* STEP 1: Email Input */}
       {step === 'idle' && (
         <form
-          onSubmit={phoneForm.handleSubmit(onPhoneSubmit)}
+          onSubmit={emailForm.handleSubmit(onEmailSubmit)}
           className="bg-white rounded-2xl shadow-lg p-6 border-t-4 border-t-secondary border border-gray-100"
         >
           <div className="flex items-center gap-2 mb-4">
@@ -249,35 +245,26 @@ export function LookupForm({ businessSlug, businessName }: LookupFormProps) {
 
           <div className="mb-6">
             <label
-              htmlFor="lookupPhone"
+              htmlFor="lookupEmail"
               className="block text-sm font-medium text-gray-700 mb-1"
             >
-              Phone Number
+              Email Address
             </label>
             <input
-              {...phoneForm.register('phone')}
-              type="tel"
-              inputMode="numeric"
-              maxLength={11}
-              id="lookupPhone"
-              placeholder="09171234567"
+              {...emailForm.register('email')}
+              type="email"
+              id="lookupEmail"
+              placeholder="juan@email.com"
               className="w-full px-4 py-3 border border-gray-300 rounded-lg bg-white text-gray-900 placeholder:text-gray-400 focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors"
               disabled={isSubmitting}
-              onKeyDown={(e) => {
-                if (
-                  ['Backspace', 'Delete', 'Tab', 'Escape', 'Enter', 'ArrowLeft', 'ArrowRight'].includes(e.key)
-                )
-                  return;
-                if (!/^\d$/.test(e.key)) e.preventDefault();
-              }}
             />
-            {phoneForm.formState.errors.phone && (
+            {emailForm.formState.errors.email && (
               <p className="mt-1 text-sm text-red-500">
-                {phoneForm.formState.errors.phone.message}
+                {emailForm.formState.errors.email.message}
               </p>
             )}
             <p className="mt-1 text-xs text-gray-500">
-              Enter the phone number you used to sign up
+              Enter the email address you used to sign up
             </p>
           </div>
 
@@ -398,7 +385,7 @@ export function LookupForm({ businessSlug, businessName }: LookupFormProps) {
           onClose={handleCloseModal}
           customerName={cardData.customerName}
           businessName={businessName}
-          phone={cardData.phone}
+          phone={cardData.phone || undefined}
           qrCodeUrl={cardData.qrCodeUrl}
           tier={cardData.tier}
           totalPoints={cardData.totalPoints}

--- a/apps/web/lib/services/public-business.service.ts
+++ b/apps/web/lib/services/public-business.service.ts
@@ -555,6 +555,7 @@ export interface CustomerByPhoneResult {
   id: string;
   fullName: string;
   email: string | null;
+  phone: string | null;
   qrCodeUrl: string;
   tier: string;
   totalPoints: number;
@@ -576,7 +577,7 @@ export async function getCustomerByPhone(
 
   const { data, error } = await supabase
     .from('customers')
-    .select('id, full_name, email, qr_code_url, tier, total_points')
+    .select('id, full_name, email, phone, qr_code_url, tier, total_points')
     .eq('phone', normalizedPhone)
     .eq('created_by_business_id', businessId)
     .maybeSingle();
@@ -589,6 +590,36 @@ export async function getCustomerByPhone(
     id: data.id,
     fullName: data.full_name || '',
     email: data.email || null,
+    phone: data.phone || null,
+    qrCodeUrl: data.qr_code_url || '',
+    tier: data.tier || 'bronze',
+    totalPoints: data.total_points || 0,
+  };
+}
+
+export async function getCustomerByEmail(
+  businessId: string,
+  email: string
+): Promise<CustomerByPhoneResult | null> {
+  const supabase = createServiceClient();
+  const normalizedEmail = email.toLowerCase().trim();
+
+  const { data, error } = await supabase
+    .from('customers')
+    .select('id, full_name, email, phone, qr_code_url, tier, total_points')
+    .eq('email', normalizedEmail)
+    .eq('created_by_business_id', businessId)
+    .maybeSingle();
+
+  if (error || !data) {
+    return null;
+  }
+
+  return {
+    id: data.id,
+    fullName: data.full_name || '',
+    email: data.email || null,
+    phone: data.phone || null,
     qrCodeUrl: data.qr_code_url || '',
     tier: data.tier || 'bronze',
     totalPoints: data.total_points || 0,
@@ -602,22 +633,26 @@ export async function getCustomerByPhone(
 export async function createSelfSignupCustomer(
   businessId: string,
   fullName: string,
-  phone: string,
+  phone: string | null | undefined,
   email?: string
 ): Promise<SelfSignupResult> {
   const supabase = createServiceClient();
 
   // Normalize inputs
-  const normalizedPhone = phone.replace(/\s+/g, '');
+  const normalizedPhone = phone ? phone.replace(/\s+/g, '') : null;
   const normalizedEmail = email?.toLowerCase().trim() || null;
 
-  // Check for existing customer by phone within this business
-  const { data: existingCustomer } = await supabase
-    .from('customers')
-    .select('id, qr_code_url, card_token, email')
-    .eq('phone', normalizedPhone)
-    .eq('created_by_business_id', businessId)
-    .maybeSingle();
+  // Check for existing customer by phone (if provided) within this business
+  let existingCustomer: { id: string; qr_code_url: string | null; card_token: string | null; email: string | null } | null = null;
+  if (normalizedPhone) {
+    const { data } = await supabase
+      .from('customers')
+      .select('id, qr_code_url, card_token, email')
+      .eq('phone', normalizedPhone)
+      .eq('created_by_business_id', businessId)
+      .maybeSingle();
+    existingCustomer = data;
+  }
 
   if (existingCustomer) {
     // Customer exists - ensure card_token exists
@@ -674,7 +709,7 @@ export async function createSelfSignupCustomer(
       user_id: null,
       email: normalizedEmail,
       full_name: fullName,
-      phone: normalizedPhone,
+      phone: normalizedPhone || null,
       total_points: 0,
       lifetime_points: 0,
       tier: 'bronze',
@@ -687,12 +722,18 @@ export async function createSelfSignupCustomer(
 
   if (createError || !newCustomer) {
     // INSERT failed — re-check for existing customer (concurrent insert race)
-    const { data: existing } = await supabase
+    let raceQuery = supabase
       .from('customers')
       .select('id, qr_code_url, card_token, email')
-      .eq('phone', normalizedPhone)
-      .eq('created_by_business_id', businessId)
-      .maybeSingle();
+      .eq('created_by_business_id', businessId);
+
+    if (normalizedPhone) {
+      raceQuery = raceQuery.eq('phone', normalizedPhone);
+    } else if (normalizedEmail) {
+      raceQuery = raceQuery.eq('email', normalizedEmail);
+    }
+
+    const { data: existing } = await raceQuery.maybeSingle();
 
     if (!existing) {
       console.error('Create self-signup customer error:', createError);


### PR DESCRIPTION
Since OTP codes are sent via email (no SMS), the card lookup flow now uses email directly instead of requiring a phone number. Phone remains required for signup but is conditionally displayed on the card modal.


Closes #56 