### PR TITLE
fix: save all signup data to business record and auto-generate join code

### DIFF
--- a/apps/web/app/api/staff/customer/route.ts
+++ b/apps/web/app/api/staff/customer/route.ts
@@ -1,5 +1,6 @@
 // apps/web/app/api/staff/customer/route.ts
 
+import crypto from 'crypto';
 import { NextRequest, NextResponse } from 'next/server';
 import {
   createServiceClient,
@@ -204,13 +205,16 @@ export async function POST(request: NextRequest) {
     }
 
     // 6. Send invite email
-    const joinCode = staffInfo.business.join_code;
+    let joinCode = staffInfo.business.join_code;
 
+    // Auto-generate join code for existing accounts that don't have one
     if (!joinCode) {
-      return NextResponse.json(
-        { error: 'Your business does not have a join code configured. Please generate one in Dashboard Settings before inviting customers.' },
-        { status: 400 },
-      );
+      joinCode = crypto.randomBytes(4).toString('hex').toUpperCase();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (serviceClient as any)
+        .from('businesses')
+        .update({ join_code: joinCode })
+        .eq('id', staffInfo.business.id);
     }
 
     const protocol = request.headers.get('x-forwarded-proto') || 'http';

--- a/apps/web/app/dashboard/settings/page.tsx
+++ b/apps/web/app/dashboard/settings/page.tsx
@@ -255,6 +255,18 @@ export default function SettingsPage() {
           logoUrl: business.logo_url,
         });
 
+        // Backfill missing fields from auth metadata for existing accounts
+        if (!business.business_type || !business.phone || !business.owner_email) {
+          const updates: Record<string, string> = {};
+          if (!business.business_type && metadata.business_type) updates.business_type = metadata.business_type;
+          if (!business.phone && metadata.phone) updates.phone = metadata.phone;
+          if (!business.owner_email && user.email) updates.owner_email = user.email;
+
+          if (Object.keys(updates).length > 0) {
+            await supabase.from('businesses').update(updates).eq('id', business.id);
+          }
+        }
+
         setReferralRewardPoints((business as Record<string, unknown>).referral_reward_points as number ?? 25);
 
         setInputValues({

--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -11,6 +11,15 @@ type StaffRole = 'owner' | 'manager' | 'cashier';
 type Business = Database['public']['Tables']['businesses']['Row'];
 
 // Helper to generate URL-safe slug from business name
+function generateJoinCode(): string {
+  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  let code = '';
+  for (let i = 0; i < 8; i++) {
+    code += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return code;
+}
+
 function generateSlug(name: string): string {
   const base = name
     .toLowerCase()
@@ -279,6 +288,10 @@ export async function completeSignupAfterVerification(): Promise<AuthResponse> {
         name: businessName,
         slug: generateSlug(businessName),
         points_per_purchase: 10,
+        business_type: metadata?.business_type || null,
+        phone: metadata?.phone || null,
+        owner_email: user.email || null,
+        join_code: generateJoinCode(),
       })
       .select()
       .single();
@@ -412,6 +425,10 @@ export async function loginBusinessOwner(
             name: businessName,
             slug: generateSlug(businessName),
             points_per_purchase: 10,
+            business_type: metadata?.business_type || null,
+            phone: metadata?.phone || null,
+            owner_email: authData.user.email || null,
+            join_code: generateJoinCode(),
           })
           .select()
           .single();


### PR DESCRIPTION
- Save business_type, phone, owner_email, and join_code during signup
- Backfill missing fields from auth metadata on settings page load
- Auto-generate join code in invite API for existing accounts without one