### PR TITLE
feat: replace email OTP card lookup with phone + PIN authentication

### DIFF
--- a/apps/web/app/api/public/business/[slug]/lookup/route.ts
+++ b/apps/web/app/api/public/business/[slug]/lookup/route.ts
@@ -4,10 +4,9 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createServiceClient } from '@/lib/supabase-server';
 import {
   getBusinessBySlug,
-  getCustomerByEmail,
-  maskEmail,
+  getCustomerByPhone,
 } from '@/lib/services/public-business.service';
-import { sendEmailVerification } from '@/lib/services/verification.service';
+import { verifyPin, PIN_MAX_ATTEMPTS, LOCKOUT_MINUTES } from '@/lib/services/pin.service';
 import { z } from 'zod';
 import type { Json } from '../../../../../../../../packages/shared/types/database';
 
@@ -15,8 +14,15 @@ import type { Json } from '../../../../../../../../packages/shared/types/databas
 // VALIDATION SCHEMA
 // ============================================
 
-const EmailLookupSchema = z.object({
-  email: z.string().email('Please enter a valid email address'),
+const PinLookupSchema = z.object({
+  phone: z
+    .string()
+    .length(11, 'Phone number must be exactly 11 digits')
+    .regex(/^\d+$/, 'Phone number must contain only digits'),
+  pin: z
+    .string()
+    .length(4, 'PIN must be exactly 4 digits')
+    .regex(/^\d+$/, 'PIN must contain only digits'),
 });
 
 // ============================================
@@ -24,11 +30,10 @@ const EmailLookupSchema = z.object({
 // ============================================
 
 const RATE_LIMIT = {
-  maxRequests: 5,
+  maxRequests: 10,
   windowSeconds: 3600,
 };
 
-// Artificial delay range (ms) to match OTP send timing
 const ARTIFICIAL_DELAY_MS = { min: 800, max: 1500 };
 
 // ============================================
@@ -49,7 +54,7 @@ async function checkRateLimit(
 
   if (error) {
     console.error('Rate limit check failed:', error);
-    return true; // fail-open
+    return true;
   }
 
   return data === true;
@@ -80,7 +85,7 @@ function artificialDelay(): Promise<void> {
 }
 
 // ============================================
-// POST: Phone Lookup — Step 1 (send OTP)
+// POST: Phone + PIN Lookup
 // ============================================
 
 export async function POST(
@@ -122,7 +127,7 @@ export async function POST(
 
     // 3. Parse and validate input
     const body = await request.json();
-    const validation = EmailLookupSchema.safeParse(body);
+    const validation = PinLookupSchema.safeParse(body);
 
     if (!validation.success) {
       return NextResponse.json(
@@ -134,53 +139,117 @@ export async function POST(
       );
     }
 
-    const { email } = validation.data;
+    const { phone, pin } = validation.data;
 
-    // 4. Look up customer by email
-    const customer = await getCustomerByEmail(business.id, email);
+    // 4. Look up customer by phone
+    const customer = await getCustomerByPhone(business.id, phone);
 
-    // 5. If customer found, send OTP to the provided email
-    if (customer) {
-      const otpResult = await sendEmailVerification(
-        email,
-        business.id,
-        business.name,
-        'card_lookup'
-      );
+    if (!customer) {
+      await artificialDelay();
 
       await logAuditEvent(serviceClient, {
-        action: 'card_lookup_otp_sent',
+        action: 'card_lookup_not_found',
         businessId: business.id,
         details: {
-          customerId: customer.id,
-          otpSent: otpResult.success,
           processingTimeMs: Date.now() - startTime,
           ipAddress,
           userAgent,
         },
       });
 
-      if (!otpResult.success) {
-        return NextResponse.json({
-          success: false,
-          message: otpResult.error || 'Failed to send verification code. Please try again.',
-        });
-      }
-
-      return NextResponse.json({
-        success: true,
-        message: 'A verification code has been sent to your email.',
-        maskedEmail: maskEmail(email),
-      });
+      return NextResponse.json(
+        { error: 'No card found for this phone number. Please check the number or sign up first.' },
+        { status: 404 }
+      );
     }
 
-    // 6. Customer not found — artificial delay + generic response
-    await artificialDelay();
+    // 5. Check if customer has a PIN set
+    if (!customer.pinHash) {
+      return NextResponse.json(
+        {
+          needsPinSetup: true,
+        },
+        { status: 200 }
+      );
+    }
+
+    // 6. Check lockout
+    if (
+      customer.failedPinAttempts >= PIN_MAX_ATTEMPTS &&
+      customer.pinLockedUntil &&
+      new Date(customer.pinLockedUntil) > new Date()
+    ) {
+      const minutesLeft = Math.ceil(
+        (new Date(customer.pinLockedUntil).getTime() - Date.now()) / 60000
+      );
+
+      return NextResponse.json(
+        { error: `Account locked due to too many failed attempts. Try again in ${minutesLeft} minute${minutesLeft === 1 ? '' : 's'}.` },
+        { status: 429 }
+      );
+    }
+
+    // 7. Verify PIN
+    const pinValid = await verifyPin(pin, customer.pinHash);
+
+    if (!pinValid) {
+      const newAttempts = customer.failedPinAttempts + 1;
+      const updateData: Record<string, unknown> = {
+        failed_pin_attempts: newAttempts,
+      };
+
+      if (newAttempts >= PIN_MAX_ATTEMPTS) {
+        updateData.pin_locked_until = new Date(
+          Date.now() + LOCKOUT_MINUTES * 60 * 1000
+        ).toISOString();
+      }
+
+      await serviceClient
+        .from('customers')
+        .update(updateData)
+        .eq('id', customer.id);
+
+      const remaining = PIN_MAX_ATTEMPTS - newAttempts;
+
+      await logAuditEvent(serviceClient, {
+        action: 'card_lookup_pin_failed',
+        businessId: business.id,
+        details: {
+          customerId: customer.id,
+          attemptsRemaining: remaining,
+          processingTimeMs: Date.now() - startTime,
+          ipAddress,
+          userAgent,
+        },
+      });
+
+      if (remaining <= 0) {
+        return NextResponse.json(
+          { error: `Too many failed attempts. Account locked for ${LOCKOUT_MINUTES} minutes.` },
+          { status: 429 }
+        );
+      }
+
+      return NextResponse.json(
+        {
+          error: 'Incorrect PIN.',
+          attemptsRemaining: remaining,
+        },
+        { status: 401 }
+      );
+    }
+
+    // 8. PIN correct — reset failed attempts
+    await serviceClient
+      .from('customers')
+      .update({ failed_pin_attempts: 0, pin_locked_until: null })
+      .eq('id', customer.id);
 
     await logAuditEvent(serviceClient, {
-      action: 'card_lookup_not_found',
+      action: 'card_lookup_success',
       businessId: business.id,
       details: {
+        customerId: customer.id,
         processingTimeMs: Date.now() - startTime,
         ipAddress,
         userAgent,
@@ -188,11 +257,17 @@ export async function POST(
     });
 
     return NextResponse.json({
-      success: false,
-      message: 'No card found for this email address. Please check the email or sign up first.',
+      success: true,
+      data: {
+        customerName: customer.fullName,
+        phone: customer.phone || null,
+        qrCodeUrl: customer.qrCodeUrl,
+        tier: customer.tier,
+        totalPoints: customer.totalPoints,
+      },
     });
   } catch (error) {
-    console.error('Email lookup error:', error);
+    console.error('Phone+PIN lookup error:', error);
     return NextResponse.json(
       { error: 'Something went wrong. Please try again.' },
       { status: 500 }

--- a/apps/web/app/api/public/business/[slug]/pin-reset/route.ts
+++ b/apps/web/app/api/public/business/[slug]/pin-reset/route.ts
@@ -1,25 +1,25 @@
-// apps/web/app/api/public/business/[slug]/lookup/verify/route.ts
+// apps/web/app/api/public/business/[slug]/pin-reset/route.ts
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createServiceClient } from '@/lib/supabase-server';
 import {
   getBusinessBySlug,
-  getCustomerByEmail,
+  getCustomerByPhone,
 } from '@/lib/services/public-business.service';
-import { verifyCode } from '@/lib/services/verification.service';
+import { sendEmailVerification } from '@/lib/services/verification.service';
 import { z } from 'zod';
-import type { Json } from '../../../../../../../../../packages/shared/types/database';
+import type { Json } from '../../../../../../../../packages/shared/types/database';
 
 // ============================================
 // VALIDATION SCHEMA
 // ============================================
 
-const VerifySchema = z.object({
-  email: z.string().email('Please enter a valid email address'),
-  code: z
+const PinResetRequestSchema = z.object({
+  phone: z
     .string()
-    .length(6, 'Code must be 6 digits')
-    .regex(/^\d+$/, 'Code must contain only digits'),
+    .length(11, 'Phone number must be exactly 11 digits')
+    .regex(/^\d+$/, 'Phone number must contain only digits'),
+  email: z.string().email('Please enter a valid email address'),
 });
 
 // ============================================
@@ -27,12 +27,14 @@ const VerifySchema = z.object({
 // ============================================
 
 const RATE_LIMIT = {
-  maxRequests: 10,
+  maxRequests: 3,
   windowSeconds: 3600,
 };
 
+const ARTIFICIAL_DELAY_MS = { min: 800, max: 1500 };
+
 // ============================================
-// HELPER FUNCTIONS
+// HELPERS
 // ============================================
 
 async function checkRateLimit(
@@ -42,14 +44,14 @@ async function checkRateLimit(
   const { data, error } = await supabase.rpc('check_rate_limit', {
     p_identifier: ipAddress,
     p_identifier_type: 'ip_address',
-    p_action: 'card_lookup_verify',
+    p_action: 'pin_reset',
     p_max_requests: RATE_LIMIT.maxRequests,
     p_window_seconds: RATE_LIMIT.windowSeconds,
   });
 
   if (error) {
     console.error('Rate limit check failed:', error);
-    return true; // fail-open
+    return true;
   }
 
   return data === true;
@@ -72,25 +74,29 @@ async function logAuditEvent(
   });
 }
 
+function artificialDelay(): Promise<void> {
+  const ms =
+    Math.floor(Math.random() * (ARTIFICIAL_DELAY_MS.max - ARTIFICIAL_DELAY_MS.min)) +
+    ARTIFICIAL_DELAY_MS.min;
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 // ============================================
-// POST: Verify OTP — Step 2 (return card data)
+// POST: Request PIN Reset (send OTP to email)
 // ============================================
 
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ slug: string }> }
 ) {
-  const startTime = Date.now();
   const ipAddress =
     request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
     request.headers.get('x-real-ip') ||
     'unknown';
-  const userAgent = request.headers.get('user-agent') || 'unknown';
 
   try {
     const { slug } = await params;
 
-    // 1. Get business by slug
     const business = await getBusinessBySlug(slug);
     if (!business) {
       return NextResponse.json({ error: 'Business not found' }, { status: 404 });
@@ -98,95 +104,70 @@ export async function POST(
 
     const serviceClient = createServiceClient();
 
-    // 2. Rate limit by IP
     const withinLimit = await checkRateLimit(serviceClient, ipAddress);
     if (!withinLimit) {
-      await logAuditEvent(serviceClient, {
-        action: 'card_lookup_verify_rate_limited',
-        businessId: business.id,
-        details: { ipAddress, userAgent },
-      });
-
       return NextResponse.json(
-        { error: 'Too many verification attempts. Please try again in an hour.' },
+        { error: 'Too many reset attempts. Please try again in an hour.' },
         { status: 429 }
       );
     }
 
-    // 3. Parse and validate input
     const body = await request.json();
-    const validation = VerifySchema.safeParse(body);
+    const validation = PinResetRequestSchema.safeParse(body);
 
     if (!validation.success) {
       return NextResponse.json(
-        {
-          error: 'Validation failed',
-          details: validation.error.flatten().fieldErrors,
-        },
+        { error: 'Validation failed', details: validation.error.flatten().fieldErrors },
         { status: 400 }
       );
     }
 
-    const { email, code } = validation.data;
+    const { phone, email } = validation.data;
 
-    // 4. Look up customer by email
-    const customer = await getCustomerByEmail(business.id, email);
-    if (!customer) {
-      return NextResponse.json(
-        { error: 'Verification failed. Please try looking up your card again.' },
-        { status: 400 }
-      );
-    }
+    // Look up customer by phone
+    const customer = await getCustomerByPhone(business.id, phone);
 
-    // 5. Verify the OTP code
-    const verifyResult = await verifyCode(code, email, business.id);
-
-    if (!verifyResult.success) {
-      await logAuditEvent(serviceClient, {
-        action: 'card_lookup_verify_failed',
-        businessId: business.id,
-        details: {
-          customerId: customer.id,
-          attemptsRemaining: verifyResult.attemptsRemaining,
-          processingTimeMs: Date.now() - startTime,
-          ipAddress,
-          userAgent,
-        },
+    // Verify email matches (prevent enumeration by always responding the same)
+    if (!customer || !customer.email || customer.email.toLowerCase() !== email.toLowerCase().trim()) {
+      await artificialDelay();
+      // Generic success to prevent enumeration
+      return NextResponse.json({
+        success: true,
+        message: 'If an account exists with that phone and email, a verification code has been sent.',
       });
-
-      return NextResponse.json(
-        {
-          error: verifyResult.error || 'Invalid verification code.',
-          attemptsRemaining: verifyResult.attemptsRemaining,
-        },
-        { status: 400 }
-      );
     }
 
-    // 6. OTP verified — return card data
+    // Send OTP
+    const otpResult = await sendEmailVerification(
+      email,
+      business.id,
+      business.name,
+      'pin_reset'
+    );
+
     await logAuditEvent(serviceClient, {
-      action: 'card_lookup_verified',
+      action: 'pin_reset_otp_sent',
       businessId: business.id,
       details: {
         customerId: customer.id,
-        processingTimeMs: Date.now() - startTime,
+        otpSent: otpResult.success,
         ipAddress,
-        userAgent,
       },
     });
 
+    if (!otpResult.success) {
+      return NextResponse.json(
+        { error: otpResult.error || 'Failed to send verification code. Please try again.' },
+        { status: 500 }
+      );
+    }
+
     return NextResponse.json({
       success: true,
-      data: {
-        customerName: customer.fullName,
-        phone: customer.phone || null,
-        qrCodeUrl: customer.qrCodeUrl,
-        tier: customer.tier,
-        totalPoints: customer.totalPoints,
-      },
+      message: 'If an account exists with that phone and email, a verification code has been sent.',
     });
   } catch (error) {
-    console.error('Lookup verify error:', error);
+    console.error('PIN reset request error:', error);
     return NextResponse.json(
       { error: 'Something went wrong. Please try again.' },
       { status: 500 }

--- a/apps/web/app/api/public/business/[slug]/pin-reset/verify/route.ts
+++ b/apps/web/app/api/public/business/[slug]/pin-reset/verify/route.ts
@@ -1,0 +1,178 @@
+// apps/web/app/api/public/business/[slug]/pin-reset/verify/route.ts
+
+import { NextRequest, NextResponse } from 'next/server';
+import { createServiceClient } from '@/lib/supabase-server';
+import { getBusinessBySlug } from '@/lib/services/public-business.service';
+import { verifyCode } from '@/lib/services/verification.service';
+import { hashPin } from '@/lib/services/pin.service';
+import { z } from 'zod';
+import type { Json } from '../../../../../../../../../packages/shared/types/database';
+
+// ============================================
+// VALIDATION SCHEMA
+// ============================================
+
+const PinResetVerifySchema = z.object({
+  email: z.string().email('Please enter a valid email address'),
+  code: z
+    .string()
+    .length(6, 'Code must be 6 digits')
+    .regex(/^\d+$/, 'Code must contain only digits'),
+  newPin: z
+    .string()
+    .length(4, 'PIN must be exactly 4 digits')
+    .regex(/^\d+$/, 'PIN must contain only digits'),
+});
+
+// ============================================
+// CONSTANTS
+// ============================================
+
+const RATE_LIMIT = {
+  maxRequests: 10,
+  windowSeconds: 3600,
+};
+
+// ============================================
+// HELPERS
+// ============================================
+
+async function checkRateLimit(
+  supabase: ReturnType<typeof createServiceClient>,
+  ipAddress: string
+): Promise<boolean> {
+  const { data, error } = await supabase.rpc('check_rate_limit', {
+    p_identifier: ipAddress,
+    p_identifier_type: 'ip_address',
+    p_action: 'pin_reset_verify',
+    p_max_requests: RATE_LIMIT.maxRequests,
+    p_window_seconds: RATE_LIMIT.windowSeconds,
+  });
+
+  if (error) {
+    console.error('Rate limit check failed:', error);
+    return true;
+  }
+
+  return data === true;
+}
+
+async function logAuditEvent(
+  supabase: ReturnType<typeof createServiceClient>,
+  params: {
+    action: string;
+    businessId: string;
+    details: Record<string, unknown>;
+  }
+) {
+  await supabase.from('audit_logs').insert({
+    event_type: params.action,
+    severity: 'info',
+    business_id: params.businessId,
+    user_id: null,
+    details: params.details as Json,
+  });
+}
+
+// ============================================
+// POST: Verify OTP + Set New PIN
+// ============================================
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const ipAddress =
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    request.headers.get('x-real-ip') ||
+    'unknown';
+
+  try {
+    const { slug } = await params;
+
+    const business = await getBusinessBySlug(slug);
+    if (!business) {
+      return NextResponse.json({ error: 'Business not found' }, { status: 404 });
+    }
+
+    const serviceClient = createServiceClient();
+
+    const withinLimit = await checkRateLimit(serviceClient, ipAddress);
+    if (!withinLimit) {
+      return NextResponse.json(
+        { error: 'Too many attempts. Please try again in an hour.' },
+        { status: 429 }
+      );
+    }
+
+    const body = await request.json();
+    const validation = PinResetVerifySchema.safeParse(body);
+
+    if (!validation.success) {
+      return NextResponse.json(
+        { error: 'Validation failed', details: validation.error.flatten().fieldErrors },
+        { status: 400 }
+      );
+    }
+
+    const { email, code, newPin } = validation.data;
+    const normalizedEmail = email.toLowerCase().trim();
+
+    // Verify OTP
+    const verifyResult = await verifyCode(code, normalizedEmail, business.id);
+
+    if (!verifyResult.success) {
+      await logAuditEvent(serviceClient, {
+        action: 'pin_reset_verify_failed',
+        businessId: business.id,
+        details: { attemptsRemaining: verifyResult.attemptsRemaining, ipAddress },
+      });
+
+      return NextResponse.json(
+        {
+          error: verifyResult.error || 'Invalid verification code.',
+          attemptsRemaining: verifyResult.attemptsRemaining,
+        },
+        { status: 400 }
+      );
+    }
+
+    // Hash new PIN and update customer
+    const pinHash = await hashPin(newPin);
+
+    const { error: updateError } = await serviceClient
+      .from('customers')
+      .update({
+        pin_hash: pinHash,
+        failed_pin_attempts: 0,
+        pin_locked_until: null,
+      })
+      .eq('email', normalizedEmail)
+      .eq('created_by_business_id', business.id);
+
+    if (updateError) {
+      console.error('Failed to update PIN:', updateError);
+      return NextResponse.json(
+        { error: 'Failed to update PIN. Please try again.' },
+        { status: 500 }
+      );
+    }
+
+    await logAuditEvent(serviceClient, {
+      action: 'pin_reset_success',
+      businessId: business.id,
+      details: { ipAddress },
+    });
+
+    return NextResponse.json({
+      success: true,
+      message: 'PIN updated successfully.',
+    });
+  } catch (error) {
+    console.error('PIN reset verify error:', error);
+    return NextResponse.json(
+      { error: 'Something went wrong. Please try again.' },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/app/api/public/business/[slug]/signup/route.ts
+++ b/apps/web/app/api/public/business/[slug]/signup/route.ts
@@ -7,6 +7,7 @@ import {
   createSelfSignupCustomer,
 } from '@/lib/services/public-business.service';
 import { hasVerifiedCode } from '@/lib/services/verification.service';
+import { hashPin } from '@/lib/services/pin.service';
 import { z } from 'zod';
 import type { Json } from '../../../../../../../../packages/shared/types/database';
 
@@ -27,6 +28,10 @@ const SelfSignupSchema = z.object({
     .string()
     .email('Invalid email address')
     .min(1, 'Email is required'),
+  pin: z
+    .string()
+    .length(4, 'PIN must be exactly 4 digits')
+    .regex(/^\d+$/, 'PIN must contain only digits'),
   referralCode: z.string().max(10).optional(),
 });
 
@@ -143,7 +148,7 @@ export async function POST(
       );
     }
 
-    const { fullName, phone, email, referralCode } = validation.data;
+    const { fullName, phone, email, pin, referralCode } = validation.data;
 
     // 3b. Require email verification (lockdown: no unverified signups)
     const isVerified = await hasVerifiedCode(email, business.id);
@@ -179,6 +184,17 @@ export async function POST(
       phone,
       email,
     );
+
+    // 4b. Hash and store PIN
+    try {
+      const pinHash = await hashPin(pin);
+      await serviceClient
+        .from('customers')
+        .update({ pin_hash: pinHash })
+        .eq('id', result.customerId);
+    } catch (pinErr) {
+      console.error('Failed to store PIN hash:', pinErr);
+    }
 
     // 5. Complete referral if code provided
     let referralResult = null;

--- a/apps/web/app/api/public/join/[code]/signup/route.ts
+++ b/apps/web/app/api/public/join/[code]/signup/route.ts
@@ -6,6 +6,7 @@ import { getBusinessByJoinCode } from '@/lib/services/public-business.service';
 import { createSelfSignupCustomer } from '@/lib/services/public-business.service';
 import { hasVerifiedCode } from '@/lib/services/verification.service';
 import { createServiceClient } from '@/lib/supabase-server';
+import { hashPin } from '@/lib/services/pin.service';
 import type { Json } from '../../../../../../../../packages/shared/types/database';
 
 // ============================================
@@ -22,6 +23,10 @@ const JoinSignupSchema = z.object({
     .length(11, 'Phone number must be exactly 11 digits')
     .regex(/^\d+$/, 'Phone number must contain only digits'),
   email: z.string().email('Invalid email address'),
+  pin: z
+    .string()
+    .length(4, 'PIN must be exactly 4 digits')
+    .regex(/^\d+$/, 'PIN must contain only digits'),
   referralCode: z.string().max(10).optional(),
 });
 
@@ -65,7 +70,7 @@ export async function POST(
       );
     }
 
-    const { fullName, phone, email, referralCode } = validation.data;
+    const { fullName, phone, email, pin, referralCode } = validation.data;
 
     // 3. Require email verification
     const verified = await hasVerifiedCode(email, business.id);
@@ -134,7 +139,8 @@ export async function POST(
       email,
     );
 
-    // 6. Mark customer as verified (columns added via migration, not yet in generated types)
+    // 6. Mark customer as verified and store PIN hash
+    const pinHash = await hashPin(pin);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await (serviceClient as any)
       .from('customers')
@@ -142,6 +148,7 @@ export async function POST(
         is_verified: true,
         verified_at: new Date().toISOString(),
         verification_method: 'email_otp',
+        pin_hash: pinHash,
       })
       .eq('id', result.customerId);
 

--- a/apps/web/app/business/[slug]/card/lookup-form.tsx
+++ b/apps/web/app/business/[slug]/card/lookup-form.tsx
@@ -6,26 +6,50 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { Loader2, AlertCircle, Search, ShieldCheck, ArrowLeft } from 'lucide-react';
+import { Loader2, AlertCircle, Search, Lock, ShieldCheck, ArrowLeft, KeyRound, Info } from 'lucide-react';
 import { CardModal } from './card-modal';
 
 // ============================================
 // VALIDATION SCHEMAS
 // ============================================
 
-const EmailLookupSchema = z.object({
+const PinLookupSchema = z.object({
+  phone: z
+    .string()
+    .length(11, 'Phone number must be exactly 11 digits')
+    .regex(/^\d+$/, 'Phone number must contain only digits'),
+  pin: z
+    .string()
+    .length(4, 'PIN must be exactly 4 digits')
+    .regex(/^\d+$/, 'PIN must contain only digits'),
+});
+
+const PinResetRequestSchema = z.object({
+  phone: z
+    .string()
+    .length(11, 'Phone number must be exactly 11 digits')
+    .regex(/^\d+$/, 'Phone number must contain only digits'),
   email: z.string().email('Please enter a valid email address'),
 });
 
-const OtpSchema = z.object({
+const PinResetVerifySchema = z.object({
   code: z
     .string()
     .length(6, 'Code must be 6 digits')
     .regex(/^\d+$/, 'Code must contain only digits'),
+  newPin: z
+    .string()
+    .length(4, 'PIN must be exactly 4 digits')
+    .regex(/^\d+$/, 'PIN must contain only digits'),
+  confirmPin: z.string(),
+}).refine((data) => data.newPin === data.confirmPin, {
+  message: 'PINs do not match',
+  path: ['confirmPin'],
 });
 
-type EmailLookupInput = z.infer<typeof EmailLookupSchema>;
-type OtpInput = z.infer<typeof OtpSchema>;
+type PinLookupInput = z.infer<typeof PinLookupSchema>;
+type PinResetRequestInput = z.infer<typeof PinResetRequestSchema>;
+type PinResetVerifyInput = z.infer<typeof PinResetVerifySchema>;
 
 // ============================================
 // TYPES
@@ -44,36 +68,40 @@ interface CardData {
   totalPoints: number;
 }
 
-type Step = 'idle' | 'otp_sent' | 'verified';
+type Step = 'lookup' | 'pin_setup_prompt' | 'reset_request' | 'reset_verify';
 
 // ============================================
 // COMPONENT
 // ============================================
 
 export function LookupForm({ businessSlug, businessName }: LookupFormProps) {
-  const [step, setStep] = useState<Step>('idle');
+  const [step, setStep] = useState<Step>('lookup');
   const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [cardData, setCardData] = useState<CardData | null>(null);
-  const [maskedEmail, setMaskedEmail] = useState<string | null>(null);
-  const [email, setEmail] = useState<string>('');
-  const [resendCooldown, setResendCooldown] = useState(0);
+  const [resetEmail, setResetEmail] = useState('');
 
-  const emailForm = useForm<EmailLookupInput>({
-    resolver: zodResolver(EmailLookupSchema),
-    defaultValues: { email: '' },
+  const lookupForm = useForm<PinLookupInput>({
+    resolver: zodResolver(PinLookupSchema),
+    defaultValues: { phone: '', pin: '' },
   });
 
-  const otpForm = useForm<OtpInput>({
-    resolver: zodResolver(OtpSchema),
-    defaultValues: { code: '' },
+  const resetRequestForm = useForm<PinResetRequestInput>({
+    resolver: zodResolver(PinResetRequestSchema),
+    defaultValues: { phone: '', email: '' },
+  });
+
+  const resetVerifyForm = useForm<PinResetVerifyInput>({
+    resolver: zodResolver(PinResetVerifySchema),
+    defaultValues: { code: '', newPin: '', confirmPin: '' },
   });
 
   // ============================================
-  // STEP 1: Submit phone — send OTP
+  // LOOKUP: Phone + PIN
   // ============================================
 
-  const onEmailSubmit = async (data: EmailLookupInput) => {
+  const onLookupSubmit = async (data: PinLookupInput) => {
     setIsSubmitting(true);
     setError(null);
 
@@ -87,46 +115,7 @@ export function LookupForm({ businessSlug, businessName }: LookupFormProps) {
       const json = await response.json();
 
       if (!response.ok) {
-        setError(json.error || 'Something went wrong. Please try again.');
-        return;
-      }
-
-      if (!json.success) {
-        setError(json.message || 'No card found for this email address.');
-        return;
-      }
-
-      // OTP sent successfully
-      setEmail(data.email);
-      setMaskedEmail(json.maskedEmail || null);
-      setStep('otp_sent');
-      startResendCooldown();
-    } catch {
-      setError('Network error. Please check your connection.');
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  // ============================================
-  // STEP 2: Verify OTP — get card data
-  // ============================================
-
-  const onOtpSubmit = async (data: OtpInput) => {
-    setIsSubmitting(true);
-    setError(null);
-
-    try {
-      const response = await fetch(`/api/public/business/${businessSlug}/lookup/verify`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email, code: data.code }),
-      });
-
-      const json = await response.json();
-
-      if (!response.ok) {
-        const msg = json.error || 'Invalid verification code.';
+        const msg = json.error || 'Something went wrong. Please try again.';
         const remaining = json.attemptsRemaining;
         setError(
           remaining !== undefined
@@ -136,7 +125,12 @@ export function LookupForm({ businessSlug, businessName }: LookupFormProps) {
         return;
       }
 
-      // Success — show card
+      // Existing customer without PIN
+      if (json.needsPinSetup) {
+        setStep('pin_setup_prompt');
+        return;
+      }
+
       setCardData({
         customerName: json.data.customerName,
         phone: json.data.phone || null,
@@ -144,7 +138,6 @@ export function LookupForm({ businessSlug, businessName }: LookupFormProps) {
         tier: json.data.tier,
         totalPoints: json.data.totalPoints,
       });
-      setStep('verified');
     } catch {
       setError('Network error. Please check your connection.');
     } finally {
@@ -153,70 +146,100 @@ export function LookupForm({ businessSlug, businessName }: LookupFormProps) {
   };
 
   // ============================================
-  // RESEND CODE
+  // PIN RESET: Request OTP
   // ============================================
 
-  const handleResend = async () => {
-    if (resendCooldown > 0) return;
-
+  const onResetRequest = async (data: PinResetRequestInput) => {
+    setIsSubmitting(true);
     setError(null);
+
     try {
-      const response = await fetch(`/api/public/business/${businessSlug}/lookup`, {
+      const response = await fetch(`/api/public/business/${businessSlug}/pin-reset`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email }),
+        body: JSON.stringify(data),
       });
 
       const json = await response.json();
 
       if (!response.ok) {
-        setError(json.error || 'Failed to resend code.');
+        setError(json.error || 'Something went wrong. Please try again.');
         return;
       }
 
-      if (!json.success) {
-        setError(json.message || 'Failed to resend code.');
-        return;
-      }
-
-      startResendCooldown();
+      setResetEmail(data.email);
+      setStep('reset_verify');
     } catch {
-      setError('Network error.');
+      setError('Network error. Please check your connection.');
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
-  const startResendCooldown = () => {
-    setResendCooldown(60);
-    const interval = setInterval(() => {
-      setResendCooldown((prev) => {
-        if (prev <= 1) {
-          clearInterval(interval);
-          return 0;
-        }
-        return prev - 1;
+  // ============================================
+  // PIN RESET: Verify OTP + Set New PIN
+  // ============================================
+
+  const onResetVerify = async (data: PinResetVerifyInput) => {
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const response = await fetch(`/api/public/business/${businessSlug}/pin-reset/verify`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: resetEmail,
+          code: data.code,
+          newPin: data.newPin,
+        }),
       });
-    }, 1000);
+
+      const json = await response.json();
+
+      if (!response.ok) {
+        setError(json.error || 'Failed to reset PIN. Please try again.');
+        return;
+      }
+
+      setSuccess('PIN updated successfully! You can now view your card.');
+      setStep('lookup');
+      resetVerifyForm.reset();
+      resetRequestForm.reset();
+    } catch {
+      setError('Network error. Please check your connection.');
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   // ============================================
-  // BACK TO PHONE STEP
+  // NAVIGATION
   // ============================================
 
-  const handleBack = () => {
-    setStep('idle');
+  const goToForgotPin = () => {
+    setStep('reset_request');
     setError(null);
-    setMaskedEmail(null);
-    otpForm.reset();
+    setSuccess(null);
+  };
+
+  const goToLookup = () => {
+    setStep('lookup');
+    setError(null);
+    setSuccess(null);
+    resetRequestForm.reset();
+    resetVerifyForm.reset();
   };
 
   const handleCloseModal = () => {
     setCardData(null);
-    setStep('idle');
     setError(null);
-    setMaskedEmail(null);
-    setEmail('');
-    emailForm.reset();
-    otpForm.reset();
+    lookupForm.reset();
+  };
+
+  const digitOnlyKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (['Backspace', 'Delete', 'Tab', 'Escape', 'Enter', 'ArrowLeft', 'ArrowRight'].includes(e.key)) return;
+    if (!/^\d$/.test(e.key)) e.preventDefault();
   };
 
   // ============================================
@@ -225,10 +248,10 @@ export function LookupForm({ businessSlug, businessName }: LookupFormProps) {
 
   return (
     <>
-      {/* STEP 1: Email Input */}
-      {step === 'idle' && (
+      {/* LOOKUP: Phone + PIN */}
+      {step === 'lookup' && !cardData && (
         <form
-          onSubmit={emailForm.handleSubmit(onEmailSubmit)}
+          onSubmit={lookupForm.handleSubmit(onLookupSubmit)}
           className="bg-white rounded-2xl shadow-lg p-6 border-t-4 border-t-secondary border border-gray-100"
         >
           <div className="flex items-center gap-2 mb-4">
@@ -243,29 +266,59 @@ export function LookupForm({ businessSlug, businessName }: LookupFormProps) {
             </div>
           )}
 
-          <div className="mb-6">
-            <label
-              htmlFor="lookupEmail"
-              className="block text-sm font-medium text-gray-700 mb-1"
-            >
-              Email Address
+          {success && (
+            <div className="mb-4 p-3 bg-green-50 border border-green-200 rounded-lg">
+              <p className="text-sm text-green-700">{success}</p>
+            </div>
+          )}
+
+          {/* Phone */}
+          <div className="mb-4">
+            <label htmlFor="lookupPhone" className="block text-sm font-medium text-gray-700 mb-1">
+              Phone Number
             </label>
             <input
-              {...emailForm.register('email')}
-              type="email"
-              id="lookupEmail"
-              placeholder="juan@email.com"
+              {...lookupForm.register('phone')}
+              type="tel"
+              inputMode="numeric"
+              maxLength={11}
+              id="lookupPhone"
+              placeholder="09171234567"
               className="w-full px-4 py-3 border border-gray-300 rounded-lg bg-white text-gray-900 placeholder:text-gray-400 focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors"
               disabled={isSubmitting}
+              onKeyDown={digitOnlyKeyDown}
             />
-            {emailForm.formState.errors.email && (
+            {lookupForm.formState.errors.phone && (
               <p className="mt-1 text-sm text-red-500">
-                {emailForm.formState.errors.email.message}
+                {lookupForm.formState.errors.phone.message}
               </p>
             )}
-            <p className="mt-1 text-xs text-gray-500">
-              Enter the email address you used to sign up
-            </p>
+          </div>
+
+          {/* PIN */}
+          <div className="mb-6">
+            <label htmlFor="lookupPin" className="block text-sm font-medium text-gray-700 mb-1">
+              4-Digit PIN
+            </label>
+            <div className="relative">
+              <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+              <input
+                {...lookupForm.register('pin')}
+                type="password"
+                inputMode="numeric"
+                maxLength={4}
+                id="lookupPin"
+                placeholder="••••"
+                className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-lg bg-white text-gray-900 placeholder:text-gray-400 focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors"
+                disabled={isSubmitting}
+                onKeyDown={digitOnlyKeyDown}
+              />
+            </div>
+            {lookupForm.formState.errors.pin && (
+              <p className="mt-1 text-sm text-red-500">
+                {lookupForm.formState.errors.pin.message}
+              </p>
+            )}
           </div>
 
           <button
@@ -282,18 +335,73 @@ export function LookupForm({ businessSlug, businessName }: LookupFormProps) {
               'View My Card'
             )}
           </button>
+
+          <div className="mt-3 text-center">
+            <button
+              type="button"
+              onClick={goToForgotPin}
+              className="text-xs text-primary hover:underline"
+            >
+              Forgot PIN?
+            </button>
+          </div>
         </form>
       )}
 
-      {/* STEP 2: OTP Input */}
-      {step === 'otp_sent' && (
+      {/* PIN SETUP PROMPT: For existing customers without PIN */}
+      {step === 'pin_setup_prompt' && (
+        <div className="bg-white rounded-2xl shadow-lg p-6 border-t-4 border-t-secondary border border-gray-100">
+          <button
+            type="button"
+            onClick={goToLookup}
+            className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 mb-4 transition-colors"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Back
+          </button>
+
+          <div className="flex items-center gap-2 mb-3">
+            <Info className="w-5 h-5 text-blue-500" />
+            <h2 className="text-lg font-semibold text-gray-900">Set Up Your PIN</h2>
+          </div>
+
+          <div className="mb-5 p-4 bg-blue-50 border border-blue-200 rounded-lg">
+            <p className="text-sm text-blue-800 mb-2">
+              We&apos;ve upgraded to a faster, more secure way to view your card — no more email codes!
+            </p>
+            <p className="text-sm text-blue-700">
+              Set a 4-digit PIN now and you&apos;ll be able to view your card instantly using just your phone number and PIN.
+            </p>
+          </div>
+
+          <button
+            type="button"
+            onClick={() => {
+              // Pre-fill phone from lookup form
+              const phone = lookupForm.getValues('phone');
+              if (phone) {
+                resetRequestForm.setValue('phone', phone);
+              }
+              setStep('reset_request');
+              setError(null);
+            }}
+            className="w-full px-6 py-3 bg-primary text-primary-foreground rounded-lg font-medium hover:bg-primary/90 transition-colors flex items-center justify-center gap-2"
+          >
+            <KeyRound className="w-4 h-4" />
+            Set My PIN
+          </button>
+        </div>
+      )}
+
+      {/* PIN RESET: Request */}
+      {step === 'reset_request' && (
         <form
-          onSubmit={otpForm.handleSubmit(onOtpSubmit)}
+          onSubmit={resetRequestForm.handleSubmit(onResetRequest)}
           className="bg-white rounded-2xl shadow-lg p-6 border-t-4 border-t-secondary border border-gray-100"
         >
           <button
             type="button"
-            onClick={handleBack}
+            onClick={goToLookup}
             className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 mb-4 transition-colors"
           >
             <ArrowLeft className="w-4 h-4" />
@@ -301,12 +409,11 @@ export function LookupForm({ businessSlug, businessName }: LookupFormProps) {
           </button>
 
           <div className="flex items-center gap-2 mb-2">
-            <ShieldCheck className="w-5 h-5 text-primary" />
-            <h2 className="text-lg font-semibold text-gray-900">Verify Your Identity</h2>
+            <KeyRound className="w-5 h-5 text-primary" />
+            <h2 className="text-lg font-semibold text-gray-900">Reset PIN</h2>
           </div>
           <p className="text-sm text-gray-500 mb-5">
-            We sent a 6-digit code to{' '}
-            <strong className="text-gray-700">{maskedEmail}</strong>
+            Enter your phone number and the email you used to sign up. We&apos;ll send a verification code to your email.
           </p>
 
           {error && (
@@ -316,27 +423,45 @@ export function LookupForm({ businessSlug, businessName }: LookupFormProps) {
             </div>
           )}
 
-          <div className="mb-6">
+          {/* Phone */}
+          <div className="mb-4">
+            <label htmlFor="resetPhone" className="block text-sm font-medium text-gray-700 mb-1">
+              Phone Number
+            </label>
             <input
-              {...otpForm.register('code')}
-              type="text"
+              {...resetRequestForm.register('phone')}
+              type="tel"
               inputMode="numeric"
-              maxLength={6}
-              placeholder="000000"
-              autoComplete="one-time-code"
+              maxLength={11}
+              id="resetPhone"
+              placeholder="09171234567"
+              className="w-full px-4 py-3 border border-gray-300 rounded-lg bg-white text-gray-900 placeholder:text-gray-400 focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors"
               disabled={isSubmitting}
-              className="w-full py-4 text-center text-3xl font-mono font-bold tracking-[0.5em] border border-gray-300 rounded-xl bg-white text-gray-900 placeholder:text-gray-300 focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors"
-              onKeyDown={(e) => {
-                if (
-                  ['Backspace', 'Delete', 'Tab', 'Escape', 'Enter', 'ArrowLeft', 'ArrowRight'].includes(e.key)
-                )
-                  return;
-                if (!/^\d$/.test(e.key)) e.preventDefault();
-              }}
+              onKeyDown={digitOnlyKeyDown}
             />
-            {otpForm.formState.errors.code && (
-              <p className="mt-1 text-xs text-red-500 text-center">
-                {otpForm.formState.errors.code.message}
+            {resetRequestForm.formState.errors.phone && (
+              <p className="mt-1 text-sm text-red-500">
+                {resetRequestForm.formState.errors.phone.message}
+              </p>
+            )}
+          </div>
+
+          {/* Email */}
+          <div className="mb-6">
+            <label htmlFor="resetEmail" className="block text-sm font-medium text-gray-700 mb-1">
+              Email Address
+            </label>
+            <input
+              {...resetRequestForm.register('email')}
+              type="email"
+              id="resetEmail"
+              placeholder="juan@email.com"
+              className="w-full px-4 py-3 border border-gray-300 rounded-lg bg-white text-gray-900 placeholder:text-gray-400 focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors"
+              disabled={isSubmitting}
+            />
+            {resetRequestForm.formState.errors.email && (
+              <p className="mt-1 text-sm text-red-500">
+                {resetRequestForm.formState.errors.email.message}
               </p>
             )}
           </div>
@@ -349,32 +474,135 @@ export function LookupForm({ businessSlug, businessName }: LookupFormProps) {
             {isSubmitting ? (
               <>
                 <Loader2 className="w-4 h-4 animate-spin" />
-                Verifying...
+                Sending code...
               </>
             ) : (
-              <>
-                <ShieldCheck className="w-4 h-4" />
-                Verify & View Card
-              </>
+              'Send Verification Code'
             )}
           </button>
+        </form>
+      )}
 
-          {/* Resend */}
-          <div className="mt-4 text-center">
-            {resendCooldown > 0 ? (
-              <p className="text-xs text-gray-400">
-                Resend code in {resendCooldown}s
+      {/* PIN RESET: Verify + New PIN */}
+      {step === 'reset_verify' && (
+        <form
+          onSubmit={resetVerifyForm.handleSubmit(onResetVerify)}
+          className="bg-white rounded-2xl shadow-lg p-6 border-t-4 border-t-secondary border border-gray-100"
+        >
+          <button
+            type="button"
+            onClick={() => { setStep('reset_request'); setError(null); }}
+            className="flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 mb-4 transition-colors"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Back
+          </button>
+
+          <div className="flex items-center gap-2 mb-2">
+            <ShieldCheck className="w-5 h-5 text-primary" />
+            <h2 className="text-lg font-semibold text-gray-900">Set New PIN</h2>
+          </div>
+          <p className="text-sm text-gray-500 mb-5">
+            Enter the 6-digit code sent to your email and choose a new 4-digit PIN.
+          </p>
+
+          {error && (
+            <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg flex items-start gap-2">
+              <AlertCircle className="w-4 h-4 text-red-500 shrink-0 mt-0.5" />
+              <p className="text-sm text-red-700">{error}</p>
+            </div>
+          )}
+
+          {/* OTP Code */}
+          <div className="mb-4">
+            <label htmlFor="resetCode" className="block text-sm font-medium text-gray-700 mb-1">
+              Verification Code
+            </label>
+            <input
+              {...resetVerifyForm.register('code')}
+              type="text"
+              inputMode="numeric"
+              maxLength={6}
+              id="resetCode"
+              placeholder="000000"
+              autoComplete="one-time-code"
+              className="w-full py-3 text-center text-2xl font-mono font-bold tracking-[0.4em] border border-gray-300 rounded-xl bg-white text-gray-900 placeholder:text-gray-300 focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors"
+              disabled={isSubmitting}
+              onKeyDown={digitOnlyKeyDown}
+            />
+            {resetVerifyForm.formState.errors.code && (
+              <p className="mt-1 text-sm text-red-500 text-center">
+                {resetVerifyForm.formState.errors.code.message}
               </p>
-            ) : (
-              <button
-                type="button"
-                onClick={handleResend}
-                className="text-xs text-primary hover:underline"
-              >
-                Didn&apos;t receive the code? Resend
-              </button>
             )}
           </div>
+
+          {/* New PIN */}
+          <div className="mb-4">
+            <label htmlFor="newPin" className="block text-sm font-medium text-gray-700 mb-1">
+              New 4-Digit PIN
+            </label>
+            <div className="relative">
+              <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+              <input
+                {...resetVerifyForm.register('newPin')}
+                type="password"
+                inputMode="numeric"
+                maxLength={4}
+                id="newPin"
+                placeholder="••••"
+                className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-lg bg-white text-gray-900 placeholder:text-gray-400 focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors"
+                disabled={isSubmitting}
+                onKeyDown={digitOnlyKeyDown}
+              />
+            </div>
+            {resetVerifyForm.formState.errors.newPin && (
+              <p className="mt-1 text-sm text-red-500">
+                {resetVerifyForm.formState.errors.newPin.message}
+              </p>
+            )}
+          </div>
+
+          {/* Confirm PIN */}
+          <div className="mb-6">
+            <label htmlFor="confirmNewPin" className="block text-sm font-medium text-gray-700 mb-1">
+              Confirm PIN
+            </label>
+            <div className="relative">
+              <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+              <input
+                {...resetVerifyForm.register('confirmPin')}
+                type="password"
+                inputMode="numeric"
+                maxLength={4}
+                id="confirmNewPin"
+                placeholder="••••"
+                className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-lg bg-white text-gray-900 placeholder:text-gray-400 focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors"
+                disabled={isSubmitting}
+                onKeyDown={digitOnlyKeyDown}
+              />
+            </div>
+            {resetVerifyForm.formState.errors.confirmPin && (
+              <p className="mt-1 text-sm text-red-500">
+                {resetVerifyForm.formState.errors.confirmPin.message}
+              </p>
+            )}
+          </div>
+
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="w-full px-6 py-3 bg-gray-900 text-white rounded-lg font-medium hover:bg-gray-800 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+          >
+            {isSubmitting ? (
+              <>
+                <Loader2 className="w-4 h-4 animate-spin" />
+                Setting PIN...
+              </>
+            ) : (
+              'Set New PIN'
+            )}
+          </button>
         </form>
       )}
 

--- a/apps/web/app/business/[slug]/card/signup-form.tsx
+++ b/apps/web/app/business/[slug]/card/signup-form.tsx
@@ -6,7 +6,7 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { Loader2, AlertCircle, UserPlus, Users } from 'lucide-react';
+import { Loader2, AlertCircle, UserPlus, Users, Lock } from 'lucide-react';
 import { CardModal } from './card-modal';
 
 // ============================================
@@ -26,7 +26,15 @@ const SelfSignupSchema = z.object({
     .string()
     .email('Invalid email address')
     .min(1, 'Email is required'),
+  pin: z
+    .string()
+    .length(4, 'PIN must be exactly 4 digits')
+    .regex(/^\d+$/, 'PIN must contain only digits'),
+  confirmPin: z.string(),
   referralCode: z.string().max(10).optional(),
+}).refine((data) => data.pin === data.confirmPin, {
+  message: 'PINs do not match',
+  path: ['confirmPin'],
 });
 
 type SelfSignupInput = z.infer<typeof SelfSignupSchema>;
@@ -68,6 +76,8 @@ export function SignupForm({ businessSlug, businessName }: SignupFormProps) {
       fullName: '',
       phone: '',
       email: '',
+      pin: '',
+      confirmPin: '',
     },
   });
 
@@ -186,6 +196,63 @@ export function SignupForm({ businessSlug, businessName }: SignupFormProps) {
           />
           {errors.email && (
             <p className="mt-1 text-sm text-red-500">{errors.email.message}</p>
+          )}
+        </div>
+
+        {/* PIN */}
+        <div className="mb-4">
+          <label htmlFor="pin" className="block text-sm font-medium text-gray-700 mb-1">
+            4-Digit PIN <span className="text-red-500">*</span>
+          </label>
+          <p className="text-xs text-gray-500 mb-1">
+            You&apos;ll use this PIN to view your card later
+          </p>
+          <div className="relative">
+            <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+            <input
+              {...register('pin')}
+              type="password"
+              inputMode="numeric"
+              maxLength={4}
+              id="pin"
+              placeholder="••••"
+              className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-lg bg-white text-gray-900 placeholder:text-gray-400 focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors"
+              disabled={isSubmitting}
+              onKeyDown={(e) => {
+                if (['Backspace', 'Delete', 'Tab', 'Escape', 'Enter', 'ArrowLeft', 'ArrowRight'].includes(e.key)) return;
+                if (!/^\d$/.test(e.key)) e.preventDefault();
+              }}
+            />
+          </div>
+          {errors.pin && (
+            <p className="mt-1 text-sm text-red-500">{errors.pin.message}</p>
+          )}
+        </div>
+
+        {/* Confirm PIN */}
+        <div className="mb-4">
+          <label htmlFor="confirmPin" className="block text-sm font-medium text-gray-700 mb-1">
+            Confirm PIN <span className="text-red-500">*</span>
+          </label>
+          <div className="relative">
+            <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+            <input
+              {...register('confirmPin')}
+              type="password"
+              inputMode="numeric"
+              maxLength={4}
+              id="confirmPin"
+              placeholder="••••"
+              className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-lg bg-white text-gray-900 placeholder:text-gray-400 focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors"
+              disabled={isSubmitting}
+              onKeyDown={(e) => {
+                if (['Backspace', 'Delete', 'Tab', 'Escape', 'Enter', 'ArrowLeft', 'ArrowRight'].includes(e.key)) return;
+                if (!/^\d$/.test(e.key)) e.preventDefault();
+              }}
+            />
+          </div>
+          {errors.confirmPin && (
+            <p className="mt-1 text-sm text-red-500">{errors.confirmPin.message}</p>
           )}
         </div>
 

--- a/apps/web/app/join/[code]/join-page-client.tsx
+++ b/apps/web/app/join/[code]/join-page-client.tsx
@@ -18,6 +18,7 @@ import {
   CreditCard,
   ArrowLeft,
   Users,
+  Lock,
 } from 'lucide-react';
 import { CardModal } from '@/app/business/[slug]/card/card-modal';
 
@@ -25,18 +26,28 @@ import { CardModal } from '@/app/business/[slug]/card/card-modal';
 // SCHEMAS
 // ============================================
 
-const Step1Schema = z.object({
-  fullName: z
-    .string()
-    .min(2, 'Name must be at least 2 characters')
-    .max(100, 'Name is too long'),
-  email: z.string().email('Invalid email address'),
-  phone: z
-    .string()
-    .length(11, 'Phone number must be exactly 11 digits')
-    .regex(/^\d+$/, 'Phone number must contain only digits'),
-  referralCode: z.string().max(10).optional(),
-});
+const Step1Schema = z
+  .object({
+    fullName: z
+      .string()
+      .min(2, 'Name must be at least 2 characters')
+      .max(100, 'Name is too long'),
+    email: z.string().email('Invalid email address'),
+    phone: z
+      .string()
+      .length(11, 'Phone number must be exactly 11 digits')
+      .regex(/^\d+$/, 'Phone number must contain only digits'),
+    pin: z
+      .string()
+      .length(4, 'PIN must be exactly 4 digits')
+      .regex(/^\d+$/, 'PIN must contain only digits'),
+    confirmPin: z.string(),
+    referralCode: z.string().max(10).optional(),
+  })
+  .refine((data) => data.pin === data.confirmPin, {
+    message: 'PINs do not match',
+    path: ['confirmPin'],
+  });
 
 const Step2Schema = z.object({
   code: z
@@ -98,6 +109,8 @@ export function JoinPageClient({
       fullName: '',
       email: prefillEmail,
       phone: '',
+      pin: '',
+      confirmPin: '',
       referralCode: '',
     },
   });
@@ -180,6 +193,7 @@ export function JoinPageClient({
           fullName: formData.fullName,
           phone: formData.phone,
           email: formData.email,
+          pin: formData.pin,
           referralCode: formData.referralCode,
         }),
       });
@@ -399,6 +413,87 @@ export function JoinPageClient({
                     {step1Form.formState.errors.phone.message}
                   </p>
                 )}
+              </div>
+
+              {/* PIN */}
+              <div className="mb-4">
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  4-Digit PIN <span className="text-red-500">*</span>
+                </label>
+                <div className="relative">
+                  <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                  <input
+                    {...step1Form.register('pin')}
+                    type="password"
+                    inputMode="numeric"
+                    maxLength={4}
+                    placeholder="Enter 4-digit PIN"
+                    disabled={isSubmitting}
+                    className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-xl bg-white text-gray-900 placeholder:text-gray-400 focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors"
+                    onKeyDown={(e) => {
+                      if (
+                        [
+                          'Backspace',
+                          'Delete',
+                          'Tab',
+                          'Escape',
+                          'Enter',
+                          'ArrowLeft',
+                          'ArrowRight',
+                        ].includes(e.key)
+                      )
+                        return;
+                      if (!/^\d$/.test(e.key)) e.preventDefault();
+                    }}
+                  />
+                </div>
+                {step1Form.formState.errors.pin && (
+                  <p className="mt-1 text-xs text-red-500">
+                    {step1Form.formState.errors.pin.message}
+                  </p>
+                )}
+              </div>
+
+              {/* Confirm PIN */}
+              <div className="mb-4">
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Confirm PIN <span className="text-red-500">*</span>
+                </label>
+                <div className="relative">
+                  <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+                  <input
+                    {...step1Form.register('confirmPin')}
+                    type="password"
+                    inputMode="numeric"
+                    maxLength={4}
+                    placeholder="Re-enter PIN"
+                    disabled={isSubmitting}
+                    className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-xl bg-white text-gray-900 placeholder:text-gray-400 focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors"
+                    onKeyDown={(e) => {
+                      if (
+                        [
+                          'Backspace',
+                          'Delete',
+                          'Tab',
+                          'Escape',
+                          'Enter',
+                          'ArrowLeft',
+                          'ArrowRight',
+                        ].includes(e.key)
+                      )
+                        return;
+                      if (!/^\d$/.test(e.key)) e.preventDefault();
+                    }}
+                  />
+                </div>
+                {step1Form.formState.errors.confirmPin && (
+                  <p className="mt-1 text-xs text-red-500">
+                    {step1Form.formState.errors.confirmPin.message}
+                  </p>
+                )}
+                <p className="mt-1 text-xs text-gray-500">
+                  You&apos;ll use this PIN to quickly look up your card.
+                </p>
               </div>
 
               {/* Referral Code (Optional) */}

--- a/apps/web/lib/services/pin.service.ts
+++ b/apps/web/lib/services/pin.service.ts
@@ -1,0 +1,14 @@
+// apps/web/lib/services/pin.service.ts
+
+import bcrypt from 'bcryptjs';
+
+export const PIN_MAX_ATTEMPTS = 5;
+export const LOCKOUT_MINUTES = 15;
+
+export async function hashPin(pin: string): Promise<string> {
+  return bcrypt.hash(pin, 10);
+}
+
+export async function verifyPin(pin: string, hash: string): Promise<boolean> {
+  return bcrypt.compare(pin, hash);
+}

--- a/apps/web/lib/services/public-business.service.ts
+++ b/apps/web/lib/services/public-business.service.ts
@@ -559,6 +559,9 @@ export interface CustomerByPhoneResult {
   qrCodeUrl: string;
   tier: string;
   totalPoints: number;
+  pinHash: string | null;
+  failedPinAttempts: number;
+  pinLockedUntil: string | null;
 }
 
 export function maskEmail(email: string): string {
@@ -577,7 +580,7 @@ export async function getCustomerByPhone(
 
   const { data, error } = await supabase
     .from('customers')
-    .select('id, full_name, email, phone, qr_code_url, tier, total_points')
+    .select('id, full_name, email, phone, qr_code_url, tier, total_points, pin_hash, failed_pin_attempts, pin_locked_until')
     .eq('phone', normalizedPhone)
     .eq('created_by_business_id', businessId)
     .maybeSingle();
@@ -594,6 +597,9 @@ export async function getCustomerByPhone(
     qrCodeUrl: data.qr_code_url || '',
     tier: data.tier || 'bronze',
     totalPoints: data.total_points || 0,
+    pinHash: data.pin_hash || null,
+    failedPinAttempts: data.failed_pin_attempts || 0,
+    pinLockedUntil: data.pin_locked_until || null,
   };
 }
 
@@ -606,7 +612,7 @@ export async function getCustomerByEmail(
 
   const { data, error } = await supabase
     .from('customers')
-    .select('id, full_name, email, phone, qr_code_url, tier, total_points')
+    .select('id, full_name, email, phone, qr_code_url, tier, total_points, pin_hash, failed_pin_attempts, pin_locked_until')
     .eq('email', normalizedEmail)
     .eq('created_by_business_id', businessId)
     .maybeSingle();
@@ -623,6 +629,9 @@ export async function getCustomerByEmail(
     qrCodeUrl: data.qr_code_url || '',
     tier: data.tier || 'bronze',
     totalPoints: data.total_points || 0,
+    pinHash: data.pin_hash || null,
+    failedPinAttempts: data.failed_pin_attempts || 0,
+    pinLockedUntil: data.pin_locked_until || null,
   };
 }
 

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -41,6 +41,7 @@
         "@supabase/supabase-js": "^2.87.1",
         "@vercel/analytics": "1.3.1",
         "autoprefixer": "^10.4.20",
+        "bcryptjs": "^3.0.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "1.0.4",
@@ -71,6 +72,7 @@
       "devDependencies": {
         "@eslint/js": "^9.39.2",
         "@tailwindcss/postcss": "^4.1.9",
+        "@types/bcryptjs": "^2.4.6",
         "@types/node": "^22",
         "@types/qrcode": "^1.5.6",
         "@types/react": "^19",
@@ -3157,6 +3159,13 @@
         "tailwindcss": "4.1.17"
       }
     },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
@@ -3725,6 +3734,15 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
       }
     },
     "node_modules/bidi-js": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -42,6 +42,7 @@
     "@supabase/supabase-js": "^2.87.1",
     "@vercel/analytics": "1.3.1",
     "autoprefixer": "^10.4.20",
+    "bcryptjs": "^3.0.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "1.0.4",
@@ -72,6 +73,7 @@
   "devDependencies": {
     "@eslint/js": "^9.39.2",
     "@tailwindcss/postcss": "^4.1.9",
+    "@types/bcryptjs": "^2.4.6",
     "@types/node": "^22",
     "@types/qrcode": "^1.5.6",
     "@types/react": "^19",

--- a/packages/shared/types/database.ts
+++ b/packages/shared/types/database.ts
@@ -773,12 +773,15 @@ export type Database = {
           email: string | null
           email_sent_at: string | null
           email_sent_count: number | null
+          failed_pin_attempts: number
           full_name: string | null
           id: string
           is_verified: boolean
           last_visit: string | null
           lifetime_points: number | null
           phone: string | null
+          pin_hash: string | null
+          pin_locked_until: string | null
           qr_code_url: string | null
           tier: string | null
           total_points: number | null
@@ -796,12 +799,15 @@ export type Database = {
           email?: string | null
           email_sent_at?: string | null
           email_sent_count?: number | null
+          failed_pin_attempts?: number
           full_name?: string | null
           id?: string
           is_verified?: boolean
           last_visit?: string | null
           lifetime_points?: number | null
           phone?: string | null
+          pin_hash?: string | null
+          pin_locked_until?: string | null
           qr_code_url?: string | null
           tier?: string | null
           total_points?: number | null
@@ -819,12 +825,15 @@ export type Database = {
           email?: string | null
           email_sent_at?: string | null
           email_sent_count?: number | null
+          failed_pin_attempts?: number
           full_name?: string | null
           id?: string
           is_verified?: boolean
           last_visit?: string | null
           lifetime_points?: number | null
           phone?: string | null
+          pin_hash?: string | null
+          pin_locked_until?: string | null
           qr_code_url?: string | null
           tier?: string | null
           total_points?: number | null


### PR DESCRIPTION
Switch card lookup from email-based OTP verification to phone + PIN for faster access. Add PIN fields to both slug signup and join code signup flows, with bcrypt hashing, rate-limited attempts, lockout, and PIN reset via email.