### PR TITLE
fix: mobile-first customers missing phone number and card lookup

### DIFF
--- a/apps/mobile/app/(main)/_layout.tsx
+++ b/apps/mobile/app/(main)/_layout.tsx
@@ -16,6 +16,7 @@ import {
 } from '../../src/providers/EarnPointsProvider';
 import { QuickQRModal } from '@/src/components/home';
 import { ReferralOnboardingModal } from '@/src/components/ReferralOnboardingModal';
+import { PhoneCompletionModal } from '@/src/components/PhoneCompletionModal';
 
 // ============================================
 // ICON COMPONENTS - Clean outlined style
@@ -281,6 +282,17 @@ function QRModalWrapper() {
 // MAIN LAYOUT
 // ============================================
 
+function PhoneModalWrapper() {
+  const { needsPhone, dismissPhonePrompt, submitPhone } = useAuth();
+  return (
+    <PhoneCompletionModal
+      visible={needsPhone}
+      onSubmit={submitPhone}
+      onSkip={dismissPhonePrompt}
+    />
+  );
+}
+
 function MainLayoutContent() {
   return (
     <View style={styles.container}>
@@ -298,6 +310,7 @@ function MainLayoutContent() {
       <CustomTabBar />
       <QRModalWrapper />
       <ReferralOnboardingModal />
+      <PhoneModalWrapper />
     </View>
   );
 }

--- a/apps/mobile/src/components/PhoneCompletionModal.tsx
+++ b/apps/mobile/src/components/PhoneCompletionModal.tsx
@@ -1,0 +1,184 @@
+// apps/mobile/src/components/PhoneCompletionModal.tsx
+
+import React, { useState, useCallback } from 'react';
+import {
+  Modal,
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+  KeyboardAvoidingView,
+  Platform,
+  ActivityIndicator,
+} from 'react-native';
+
+interface PhoneCompletionModalProps {
+  visible: boolean;
+  onSubmit: (phone: string) => Promise<void>;
+  onSkip: () => void;
+}
+
+export function PhoneCompletionModal({
+  visible,
+  onSubmit,
+  onSkip,
+}: PhoneCompletionModalProps) {
+  const [phone, setPhone] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = useCallback(async () => {
+    const cleaned = phone.replace(/\s+/g, '');
+    if (!/^09\d{9}$/.test(cleaned)) {
+      setError('Enter a valid 11-digit phone number (e.g. 09171234567)');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      await onSubmit(cleaned);
+    } catch {
+      setError('Failed to save phone number. Please try again.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [phone, onSubmit]);
+
+  const handleChangeText = useCallback((text: string) => {
+    // Only allow digits
+    const digits = text.replace(/\D/g, '').slice(0, 11);
+    setPhone(digits);
+    if (error) setError(null);
+  }, [error]);
+
+  return (
+    <Modal visible={visible} transparent animationType="slide">
+      <KeyboardAvoidingView
+        style={styles.overlay}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      >
+        <View style={styles.sheet}>
+          <View style={styles.handle} />
+
+          <Text style={styles.title}>Add your phone number</Text>
+          <Text style={styles.subtitle}>
+            This lets you view your loyalty card on the web using your phone
+            number and PIN.
+          </Text>
+
+          <TextInput
+            style={[styles.input, error ? styles.inputError : null]}
+            placeholder="09171234567"
+            placeholderTextColor="#9CA3AF"
+            keyboardType="number-pad"
+            maxLength={11}
+            value={phone}
+            onChangeText={handleChangeText}
+            editable={!isSubmitting}
+          />
+
+          {error && <Text style={styles.error}>{error}</Text>}
+
+          <TouchableOpacity
+            style={[styles.button, isSubmitting && styles.buttonDisabled]}
+            onPress={handleSubmit}
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? (
+              <ActivityIndicator color="#fff" size="small" />
+            ) : (
+              <Text style={styles.buttonText}>Save Phone Number</Text>
+            )}
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={styles.skipButton}
+            onPress={onSkip}
+            disabled={isSubmitting}
+          >
+            <Text style={styles.skipText}>Skip for now</Text>
+          </TouchableOpacity>
+        </View>
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    justifyContent: 'flex-end',
+    backgroundColor: 'rgba(0,0,0,0.4)',
+  },
+  sheet: {
+    backgroundColor: '#fff',
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    padding: 24,
+    paddingBottom: 40,
+  },
+  handle: {
+    width: 40,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: '#D1D5DB',
+    alignSelf: 'center',
+    marginBottom: 20,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '700',
+    color: '#111827',
+    marginBottom: 8,
+  },
+  subtitle: {
+    fontSize: 14,
+    color: '#6B7280',
+    marginBottom: 20,
+    lineHeight: 20,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: '#D1D5DB',
+    borderRadius: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    fontSize: 16,
+    color: '#111827',
+    backgroundColor: '#F9FAFB',
+  },
+  inputError: {
+    borderColor: '#EF4444',
+  },
+  error: {
+    color: '#EF4444',
+    fontSize: 13,
+    marginTop: 6,
+  },
+  button: {
+    backgroundColor: '#111827',
+    borderRadius: 12,
+    paddingVertical: 16,
+    alignItems: 'center',
+    marginTop: 20,
+  },
+  buttonDisabled: {
+    opacity: 0.6,
+  },
+  buttonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  skipButton: {
+    alignItems: 'center',
+    marginTop: 12,
+    paddingVertical: 8,
+  },
+  skipText: {
+    color: '#6B7280',
+    fontSize: 14,
+  },
+});

--- a/apps/mobile/src/providers/AuthProvider.tsx
+++ b/apps/mobile/src/providers/AuthProvider.tsx
@@ -10,6 +10,7 @@ import React, {
 } from 'react';
 import { Session, User, RealtimeChannel } from '@supabase/supabase-js';
 import { GoogleSignin } from '@react-native-google-signin/google-signin';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { supabase } from '../lib/supabase';
 import { customerService } from '../services/customer.service';
 import { notificationService } from '../services/notification.service';
@@ -26,6 +27,7 @@ interface AuthState {
   isLoading: boolean;
   isInitialized: boolean;
   isNewCustomer: boolean;
+  needsPhone: boolean;
 }
 
 interface AuthContextType extends AuthState {
@@ -33,6 +35,8 @@ interface AuthContextType extends AuthState {
   signOut: () => Promise<void>;
   refreshCustomer: () => Promise<void>;
   clearNewCustomerFlag: () => void;
+  dismissPhonePrompt: () => void;
+  submitPhone: (phone: string) => Promise<void>;
 }
 
 const initialState: AuthState = {
@@ -42,7 +46,11 @@ const initialState: AuthState = {
   isLoading: false,
   isInitialized: false,
   isNewCustomer: false,
+  needsPhone: false,
 };
+
+const PHONE_PROMPT_SKIP_KEY = 'phone_prompt_skip_count';
+const MAX_PHONE_PROMPTS = 3;
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
@@ -101,6 +109,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         const { customer, isNew } =
           await customerService.findOrCreate(profile);
 
+        // Check if phone prompt should be shown
+        let needsPhone = false;
+        if (customer && !customer.phone) {
+          const skipCountStr = await AsyncStorage.getItem(PHONE_PROMPT_SKIP_KEY);
+          const skipCount = skipCountStr ? parseInt(skipCountStr, 10) : 0;
+          needsPhone = skipCount < MAX_PHONE_PROMPTS;
+        }
+
         setState({
           user,
           customer,
@@ -109,6 +125,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           isInitialized: true,
           // Only show onboarding modal for fresh signups, not app relaunches
           isNewCustomer: fromInit ? false : isNew,
+          needsPhone,
         });
 
         if (customer?.id) {
@@ -128,6 +145,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           isLoading: false,
           isInitialized: true,
           isNewCustomer: false,
+          needsPhone: false,
         });
       } finally {
         isLoadingCustomer.current = false;
@@ -215,6 +233,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           isLoading: false,
           isInitialized: true,
           isNewCustomer: false,
+          needsPhone: false,
         });
       }
     });
@@ -274,6 +293,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         isLoading: false,
         isInitialized: true,
         isNewCustomer: false,
+        needsPhone: false,
       });
     }
   }, [cleanupRealtimeSubscription, state.customer?.id]);
@@ -281,6 +301,25 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const clearNewCustomerFlag = useCallback(() => {
     setState((prev) => ({ ...prev, isNewCustomer: false }));
   }, []);
+
+  const dismissPhonePrompt = useCallback(async () => {
+    const skipCountStr = await AsyncStorage.getItem(PHONE_PROMPT_SKIP_KEY);
+    const skipCount = skipCountStr ? parseInt(skipCountStr, 10) : 0;
+    await AsyncStorage.setItem(PHONE_PROMPT_SKIP_KEY, String(skipCount + 1));
+    setState((prev) => ({ ...prev, needsPhone: false }));
+  }, []);
+
+  const submitPhone = useCallback(async (phone: string) => {
+    if (!state.customer) return;
+    await customerService.updatePhone(state.customer.id, phone);
+    // Clear skip counter since they completed it
+    await AsyncStorage.removeItem(PHONE_PROMPT_SKIP_KEY);
+    setState((prev) => ({
+      ...prev,
+      needsPhone: false,
+      customer: prev.customer ? { ...prev.customer, phone } : null,
+    }));
+  }, [state.customer]);
 
   const refreshCustomer = useCallback(async () => {
     if (!state.user) return;
@@ -301,6 +340,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         signOut,
         refreshCustomer,
         clearNewCustomerFlag,
+        dismissPhonePrompt,
+        submitPhone,
       }}
     >
       {children}

--- a/apps/mobile/src/services/customer.service.ts
+++ b/apps/mobile/src/services/customer.service.ts
@@ -226,6 +226,22 @@ export const customerService = {
   },
 
   /**
+   * Update phone number for a customer and all linked records (same user_id).
+   * The DB trigger handles propagation, so we just update the primary record.
+   */
+  async updatePhone(customerId: string, phone: string): Promise<void> {
+    const { error } = await supabase
+      .from('customers')
+      .update({ phone })
+      .eq('id', customerId);
+
+    if (error) {
+      console.error('[CustomerService] updatePhone error:', error.message);
+      throw error;
+    }
+  },
+
+  /**
    * Get customer by ID (for staff lookups)
    */
   async getById(customerId: string): Promise<Customer | null> {

--- a/apps/web/app/api/public/business/[slug]/lookup/route.ts
+++ b/apps/web/app/api/public/business/[slug]/lookup/route.ts
@@ -5,6 +5,7 @@ import { createServiceClient } from '@/lib/supabase-server';
 import {
   getBusinessBySlug,
   getCustomerByPhone,
+  getCustomerByEmail,
 } from '@/lib/services/public-business.service';
 import { verifyPin, PIN_MAX_ATTEMPTS, LOCKOUT_MINUTES } from '@/lib/services/pin.service';
 import { z } from 'zod';
@@ -15,10 +16,7 @@ import type { Json } from '../../../../../../../../packages/shared/types/databas
 // ============================================
 
 const PinLookupSchema = z.object({
-  phone: z
-    .string()
-    .length(11, 'Phone number must be exactly 11 digits')
-    .regex(/^\d+$/, 'Phone number must contain only digits'),
+  identifier: z.string().min(1, 'Phone number or email is required'),
   pin: z
     .string()
     .length(4, 'PIN must be exactly 4 digits')
@@ -139,10 +137,22 @@ export async function POST(
       );
     }
 
-    const { phone, pin } = validation.data;
+    const { identifier, pin } = validation.data;
 
-    // 4. Look up customer by phone
-    const customer = await getCustomerByPhone(business.id, phone);
+    // 4. Detect identifier type and look up customer
+    const isEmail = identifier.includes('@');
+    const isPhone = /^\d{11}$/.test(identifier.replace(/\s+/g, ''));
+
+    if (!isEmail && !isPhone) {
+      return NextResponse.json(
+        { error: 'Please enter a valid 11-digit phone number or email address.' },
+        { status: 400 }
+      );
+    }
+
+    const customer = isEmail
+      ? await getCustomerByEmail(business.id, identifier)
+      : await getCustomerByPhone(business.id, identifier.replace(/\s+/g, ''));
 
     if (!customer) {
       await artificialDelay();
@@ -151,6 +161,7 @@ export async function POST(
         action: 'card_lookup_not_found',
         businessId: business.id,
         details: {
+          lookupType: isEmail ? 'email' : 'phone',
           processingTimeMs: Date.now() - startTime,
           ipAddress,
           userAgent,
@@ -158,7 +169,10 @@ export async function POST(
       });
 
       return NextResponse.json(
-        { error: 'No card found for this phone number. Please check the number or sign up first.' },
+        { error: isEmail
+            ? 'No card found for this email. Please check the address or sign up first.'
+            : 'No card found for this phone number. Please check the number or sign up first.'
+        },
         { status: 404 }
       );
     }

--- a/apps/web/app/api/public/business/[slug]/pin-reset/route.ts
+++ b/apps/web/app/api/public/business/[slug]/pin-reset/route.ts
@@ -5,6 +5,7 @@ import { createServiceClient } from '@/lib/supabase-server';
 import {
   getBusinessBySlug,
   getCustomerByPhone,
+  getCustomerByEmail,
 } from '@/lib/services/public-business.service';
 import { sendEmailVerification } from '@/lib/services/verification.service';
 import { z } from 'zod';
@@ -18,7 +19,8 @@ const PinResetRequestSchema = z.object({
   phone: z
     .string()
     .length(11, 'Phone number must be exactly 11 digits')
-    .regex(/^\d+$/, 'Phone number must contain only digits'),
+    .regex(/^\d+$/, 'Phone number must contain only digits')
+    .optional(),
   email: z.string().email('Please enter a valid email address'),
 });
 
@@ -124,8 +126,10 @@ export async function POST(
 
     const { phone, email } = validation.data;
 
-    // Look up customer by phone
-    const customer = await getCustomerByPhone(business.id, phone);
+    // Look up customer by phone (if provided) or by email
+    const customer = phone
+      ? await getCustomerByPhone(business.id, phone)
+      : await getCustomerByEmail(business.id, email);
 
     // Verify email matches (prevent enumeration by always responding the same)
     if (!customer || !customer.email || customer.email.toLowerCase() !== email.toLowerCase().trim()) {

--- a/apps/web/app/business/[slug]/card/card-modal.tsx
+++ b/apps/web/app/business/[slug]/card/card-modal.tsx
@@ -167,32 +167,32 @@ export function CardModal({
             >
               {/* Main content area */}
               <div className="flex-1 flex flex-col items-center justify-center px-6">
-                <h2 className="text-2xl sm:text-3xl font-bold text-white text-center leading-tight">
+                <h2 className="text-xl xs:text-2xl sm:text-3xl font-bold text-white text-center leading-tight">
                   {businessName}
                 </h2>
-                <p className="text-sm sm:text-base text-white/80 mt-1">
+                <p className="text-xs xs:text-sm sm:text-base text-white/80 mt-1">
                   Loyalty Rewards
                 </p>
               </div>
 
               {/* Tier banner */}
               <div
-                className={`${tierStyle.banner} px-6 py-2.5 flex items-center justify-between`}
+                className={`${tierStyle.banner} px-4 sm:px-6 py-2 sm:py-2.5 flex items-center justify-between`}
               >
                 <div className="flex items-center gap-2">
                   <Star className={`w-4 h-4 ${tierStyle.bannerText}`} />
                   <span
-                    className={`text-sm font-semibold ${tierStyle.bannerText}`}
+                    className={`text-xs sm:text-sm font-semibold ${tierStyle.bannerText}`}
                   >
                     {tierStyle.label} Member
                   </span>
                 </div>
                 <button
                   onClick={() => setIsFlipped(true)}
-                  className={`w-8 h-8 rounded-full flex items-center justify-center ${tierStyle.bannerText} hover:bg-black/10 transition-colors`}
+                  className={`w-7 h-7 sm:w-8 sm:h-8 rounded-full flex items-center justify-center ${tierStyle.bannerText} hover:bg-black/10 transition-colors`}
                   aria-label="Flip card"
                 >
-                  <RotateCw className="w-4 h-4" />
+                  <RotateCw className="w-3.5 h-3.5 sm:w-4 sm:h-4" />
                 </button>
               </div>
             </div>
@@ -205,54 +205,58 @@ export function CardModal({
                 transform: 'rotateY(180deg)',
               }}
             >
-              {/* Black magnetic stripe */}
-              <div className="bg-black h-7 sm:h-15 w-full mt-3 sm:mt-4" />
+              {/* Black magnetic stripe — scales with card via percentage height */}
+              <div className="bg-gradient-to-r from-neutral-900 via-neutral-800 to-neutral-900 w-full" style={{ height: '13%', marginTop: '4%' }} />
 
-              {/* Main content — side-by-side: info left, QR right */}
-              <div className="flex-1 flex items-center px-5 sm:px-6 py-3 gap-4">
+              {/* Main content — always side-by-side, scales proportionally */}
+              <div className="flex-1 flex items-center gap-2 sm:gap-4" style={{ padding: '2% 4%' }}>
                 {/* Left: avatar + customer info */}
-                <div className="flex items-center gap-3 flex-1 min-w-0">
-                  {/* Initials avatar */}
+                <div className="flex items-center gap-1.5 sm:gap-3 flex-1 min-w-0">
+                  {/* Initials avatar — percentage-driven sizing */}
                   <div
-                    className={`w-10 h-10 sm:w-12 sm:h-12 rounded-full ${tierStyle.avatar} ${tierStyle.avatarText} flex items-center justify-center text-sm sm:text-base font-bold shrink-0`}
+                    className={`rounded-full ${tierStyle.avatar} ${tierStyle.avatarText} flex items-center justify-center font-bold shrink-0`}
+                    style={{ width: '15%', maxWidth: '48px', aspectRatio: '1' , fontSize: 'clamp(10px, 2.5cqi, 16px)' }}
                   >
                     {getInitials(customerName)}
                   </div>
 
-                  {/* Customer details */}
-                  <div className="min-w-0">
-                    <h3 className="text-sm sm:text-base font-bold text-gray-900 truncate">
+                  {/* Customer details — clamp-based fluid typography */}
+                  <div className="min-w-0 flex-1">
+                    <h3
+                      className="font-bold text-gray-900 leading-tight break-words"
+                      style={{ fontSize: 'clamp(11px, 3cqi, 16px)' }}
+                    >
                       {customerName}
                     </h3>
                     {phone && (
-                      <p className="text-xs text-gray-500">
+                      <p className="text-gray-500 leading-tight" style={{ fontSize: 'clamp(9px, 2.2cqi, 12px)' }}>
                         {formatPhone(phone)}
                       </p>
                     )}
-                    <div className="flex items-center gap-1 mt-0.5">
-                      <Star className="w-3.5 h-3.5 text-amber-500" />
-                      <span className="text-xs font-semibold text-gray-700">
+                    <div className="flex items-center gap-0.5 sm:gap-1 mt-0.5">
+                      <Star className="text-amber-500 shrink-0" style={{ width: 'clamp(10px, 2.5cqi, 14px)', height: 'clamp(10px, 2.5cqi, 14px)' }} />
+                      <span className="font-semibold text-gray-700" style={{ fontSize: 'clamp(9px, 2.2cqi, 12px)' }}>
                         {totalPoints.toLocaleString()} points
                       </span>
                     </div>
                   </div>
                 </div>
 
-                {/* Right: QR Code */}
-                <div className="shrink-0">
-                  <div className="bg-white border-2 border-gray-100 rounded-lg p-1.5 shadow-sm">
+                {/* Right: QR Code — sized relative to card height */}
+                <div className="shrink-0" style={{ width: '35%', maxWidth: '152px' }}>
+                  <div className="bg-white border border-gray-200 rounded-md sm:rounded-lg shadow-sm" style={{ padding: 'clamp(2px, 1%, 6px)' }}>
                     <img
                       src={`/api/qr/${encodeURIComponent(qrCodeUrl)}`}
                       alt="Your Loyalty QR Code"
-                      className="w-32 h-32 sm:w-36 sm:h-36"
+                      className="w-full h-auto"
                     />
                   </div>
                 </div>
               </div>
 
-              {/* Footer */}
-              <div className="px-6 py-2.5 border-t border-gray-100 flex items-center justify-between">
-                <span className="text-xs text-gray-400">
+              {/* Footer — compact and proportional */}
+              <div className="border-t border-gray-100 flex items-center justify-between" style={{ padding: '1.5% 4%' }}>
+                <span className="text-gray-400" style={{ fontSize: 'clamp(8px, 2cqi, 12px)' }}>
                   Powered by{' '}
                   <span className="font-semibold text-gray-500">
                     NoxaLoyalty
@@ -260,10 +264,11 @@ export function CardModal({
                 </span>
                 <button
                   onClick={() => setIsFlipped(false)}
-                  className="w-8 h-8 rounded-full flex items-center justify-center text-gray-400 hover:bg-gray-100 transition-colors"
+                  className="rounded-full flex items-center justify-center text-gray-400 hover:bg-gray-100 transition-colors"
+                  style={{ width: 'clamp(20px, 5cqi, 32px)', height: 'clamp(20px, 5cqi, 32px)' }}
                   aria-label="Flip card"
                 >
-                  <RotateCw className="w-4 h-4" />
+                  <RotateCw style={{ width: 'clamp(10px, 2.5cqi, 16px)', height: 'clamp(10px, 2.5cqi, 16px)' }} />
                 </button>
               </div>
             </div>

--- a/apps/web/app/business/[slug]/card/lookup-form.tsx
+++ b/apps/web/app/business/[slug]/card/lookup-form.tsx
@@ -14,10 +14,19 @@ import { CardModal } from './card-modal';
 // ============================================
 
 const PinLookupSchema = z.object({
-  phone: z
+  identifier: z
     .string()
-    .length(11, 'Phone number must be exactly 11 digits')
-    .regex(/^\d+$/, 'Phone number must contain only digits'),
+    .min(1, 'Phone number or email is required')
+    .refine(
+      (val) => {
+        const trimmed = val.trim();
+        // Email
+        if (trimmed.includes('@')) return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed);
+        // Phone (11 digits)
+        return /^\d{11}$/.test(trimmed.replace(/\s+/g, ''));
+      },
+      { message: 'Enter a valid 11-digit phone number or email address' }
+    ),
   pin: z
     .string()
     .length(4, 'PIN must be exactly 4 digits')
@@ -27,8 +36,9 @@ const PinLookupSchema = z.object({
 const PinResetRequestSchema = z.object({
   phone: z
     .string()
-    .length(11, 'Phone number must be exactly 11 digits')
-    .regex(/^\d+$/, 'Phone number must contain only digits'),
+    .regex(/^\d{11}$/, 'Phone number must be exactly 11 digits')
+    .optional()
+    .or(z.literal('')),
   email: z.string().email('Please enter a valid email address'),
 });
 
@@ -81,10 +91,11 @@ export function LookupForm({ businessSlug, businessName }: LookupFormProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [cardData, setCardData] = useState<CardData | null>(null);
   const [resetEmail, setResetEmail] = useState('');
+  const [lookupWasEmail, setLookupWasEmail] = useState(false);
 
   const lookupForm = useForm<PinLookupInput>({
     resolver: zodResolver(PinLookupSchema),
-    defaultValues: { phone: '', pin: '' },
+    defaultValues: { identifier: '', pin: '' },
   });
 
   const resetRequestForm = useForm<PinResetRequestInput>({
@@ -127,6 +138,7 @@ export function LookupForm({ businessSlug, businessName }: LookupFormProps) {
 
       // Existing customer without PIN
       if (json.needsPinSetup) {
+        setLookupWasEmail(data.identifier.includes('@'));
         setStep('pin_setup_prompt');
         return;
       }
@@ -154,10 +166,13 @@ export function LookupForm({ businessSlug, businessName }: LookupFormProps) {
     setError(null);
 
     try {
+      const payload: { email: string; phone?: string } = { email: data.email };
+      if (data.phone) payload.phone = data.phone;
+
       const response = await fetch(`/api/public/business/${businessSlug}/pin-reset`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
+        body: JSON.stringify(payload),
       });
 
       const json = await response.json();
@@ -272,25 +287,22 @@ export function LookupForm({ businessSlug, businessName }: LookupFormProps) {
             </div>
           )}
 
-          {/* Phone */}
+          {/* Phone or Email */}
           <div className="mb-4">
-            <label htmlFor="lookupPhone" className="block text-sm font-medium text-gray-700 mb-1">
-              Phone Number
+            <label htmlFor="lookupIdentifier" className="block text-sm font-medium text-gray-700 mb-1">
+              Phone Number or Email
             </label>
             <input
-              {...lookupForm.register('phone')}
-              type="tel"
-              inputMode="numeric"
-              maxLength={11}
-              id="lookupPhone"
-              placeholder="09171234567"
+              {...lookupForm.register('identifier')}
+              type="text"
+              id="lookupIdentifier"
+              placeholder="09171234567 or juan@email.com"
               className="w-full px-4 py-3 border border-gray-300 rounded-lg bg-white text-gray-900 placeholder:text-gray-400 focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors"
               disabled={isSubmitting}
-              onKeyDown={digitOnlyKeyDown}
             />
-            {lookupForm.formState.errors.phone && (
+            {lookupForm.formState.errors.identifier && (
               <p className="mt-1 text-sm text-red-500">
-                {lookupForm.formState.errors.phone.message}
+                {lookupForm.formState.errors.identifier.message}
               </p>
             )}
           </div>
@@ -378,9 +390,11 @@ export function LookupForm({ businessSlug, businessName }: LookupFormProps) {
             type="button"
             onClick={() => {
               // Pre-fill phone from lookup form
-              const phone = lookupForm.getValues('phone');
-              if (phone) {
-                resetRequestForm.setValue('phone', phone);
+              const id = lookupForm.getValues('identifier');
+              if (id && id.includes('@')) {
+                resetRequestForm.setValue('email', id.trim());
+              } else if (id && /^\d+$/.test(id.replace(/\s+/g, ''))) {
+                resetRequestForm.setValue('phone', id.replace(/\s+/g, ''));
               }
               setStep('reset_request');
               setError(null);
@@ -413,7 +427,9 @@ export function LookupForm({ businessSlug, businessName }: LookupFormProps) {
             <h2 className="text-lg font-semibold text-gray-900">Reset PIN</h2>
           </div>
           <p className="text-sm text-gray-500 mb-5">
-            Enter your phone number and the email you used to sign up. We&apos;ll send a verification code to your email.
+            {lookupWasEmail
+              ? 'We\u2019ll send a verification code to your email so you can set your PIN.'
+              : 'Enter your phone number and the email you used to sign up. We\u2019ll send a verification code to your email.'}
           </p>
 
           {error && (
@@ -423,28 +439,30 @@ export function LookupForm({ businessSlug, businessName }: LookupFormProps) {
             </div>
           )}
 
-          {/* Phone */}
-          <div className="mb-4">
-            <label htmlFor="resetPhone" className="block text-sm font-medium text-gray-700 mb-1">
-              Phone Number
-            </label>
-            <input
-              {...resetRequestForm.register('phone')}
-              type="tel"
-              inputMode="numeric"
-              maxLength={11}
-              id="resetPhone"
-              placeholder="09171234567"
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg bg-white text-gray-900 placeholder:text-gray-400 focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors"
-              disabled={isSubmitting}
-              onKeyDown={digitOnlyKeyDown}
-            />
-            {resetRequestForm.formState.errors.phone && (
-              <p className="mt-1 text-sm text-red-500">
-                {resetRequestForm.formState.errors.phone.message}
-              </p>
-            )}
-          </div>
+          {/* Phone - hidden when lookup was by email */}
+          {!lookupWasEmail && (
+            <div className="mb-4">
+              <label htmlFor="resetPhone" className="block text-sm font-medium text-gray-700 mb-1">
+                Phone Number
+              </label>
+              <input
+                {...resetRequestForm.register('phone')}
+                type="tel"
+                inputMode="numeric"
+                maxLength={11}
+                id="resetPhone"
+                placeholder="09171234567"
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg bg-white text-gray-900 placeholder:text-gray-400 focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors"
+                disabled={isSubmitting}
+                onKeyDown={digitOnlyKeyDown}
+              />
+              {resetRequestForm.formState.errors.phone && (
+                <p className="mt-1 text-sm text-red-500">
+                  {resetRequestForm.formState.errors.phone.message}
+                </p>
+              )}
+            </div>
+          )}
 
           {/* Email */}
           <div className="mb-6">

--- a/supabase/migrations/20260227_auto_link_customer_on_insert.sql
+++ b/supabase/migrations/20260227_auto_link_customer_on_insert.sql
@@ -1,0 +1,32 @@
+-- Trigger function: when a customer is inserted with an email but no user_id,
+-- check auth.users for a matching email and auto-set user_id.
+CREATE OR REPLACE FUNCTION public.auto_link_customer_on_insert()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_user_id uuid;
+BEGIN
+  -- Only act if user_id is not already set and email is provided
+  IF NEW.user_id IS NULL AND NEW.email IS NOT NULL THEN
+    SELECT id INTO v_user_id
+    FROM auth.users
+    WHERE lower(email) = lower(NEW.email)
+    LIMIT 1;
+
+    IF v_user_id IS NOT NULL THEN
+      NEW.user_id := v_user_id;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+-- Create the trigger on customers table
+DROP TRIGGER IF EXISTS trg_auto_link_customer_on_insert ON public.customers;
+CREATE TRIGGER trg_auto_link_customer_on_insert
+  BEFORE INSERT ON public.customers
+  FOR EACH ROW
+  EXECUTE FUNCTION public.auto_link_customer_on_insert();


### PR DESCRIPTION
- Add smart "View My Card" lookup accepting phone OR email with auto-detection
- Add phone completion modal in mobile app (shown after Google OAuth sign-in)
- Add DB trigger to propagate phone updates to all linked customer records
- Update PIN reset flow to support email-only lookup for mobile-first customers
- Make card modal fully responsive with fluid sizing on all screen sizes