### PR TITLE
fix: persist bulk delete and handle invite email failures

### DIFF
--- a/apps/web/app/api/staff/customer/route.ts
+++ b/apps/web/app/api/staff/customer/route.ts
@@ -235,11 +235,19 @@ export async function POST(request: NextRequest) {
         max_attempts: 5,
       });
 
-    await sendCustomerInviteEmail({
+    const emailResult = await sendCustomerInviteEmail({
       to: email,
       businessName: staffInfo.business.name,
       joinUrl,
     });
+
+    if (!emailResult.success) {
+      console.error('Failed to send invite email:', emailResult.error);
+      return NextResponse.json(
+        { error: `Failed to send invitation email: ${emailResult.error}` },
+        { status: 502 },
+      );
+    }
 
     // 7. Log audit event
     await logAuditEvent(serviceClient, {

--- a/apps/web/lib/services/customer.service.ts
+++ b/apps/web/lib/services/customer.service.ts
@@ -25,7 +25,19 @@ export async function unlinkCustomersFromBusiness(
 ): Promise<UnlinkResult> {
   const supabase = createServiceClient();
 
-  // Clear created_by_business_id for customers that belong to this business
+  // 1. Remove from customer_businesses junction table
+  const { error: cbError } = await supabase
+    .from("customer_businesses")
+    .delete()
+    .in("customer_id", customerIds)
+    .eq("business_id", businessId);
+
+  if (cbError) {
+    console.error("Error removing customer_businesses links:", cbError);
+    throw cbError;
+  }
+
+  // 2. Clear created_by_business_id on customers table (if it matches this business)
   const { error, count } = await supabase
     .from("customers")
     .update({ created_by_business_id: null })


### PR DESCRIPTION
- Remove customer_businesses junction row on bulk delete so customers don't reappear after page refresh
- Check sendCustomerInviteEmail result and return proper error to frontend instead of silently ignoring failures