### PR TITLE
fix: update notification badge on realtime read status changes and sh…

### DIFF
--- a/apps/mobile/src/components/brands/BrandCard.tsx
+++ b/apps/mobile/src/components/brands/BrandCard.tsx
@@ -53,6 +53,15 @@ function BrandCardComponent({ brand, onPress }: BrandCardProps) {
           </Text>
         </View>
 
+        {brand.min_purchase_for_points != null && brand.min_purchase_for_points > 0 && (
+          <View style={styles.metaRow}>
+            <Ionicons name="cart-outline" size={14} color={COLORS.gray[400]} />
+            <Text style={styles.metaText}>
+              Min. ₱{brand.min_purchase_for_points} per purchase
+            </Text>
+          </View>
+        )}
+
         {brand.points_per_purchase != null && brand.points_per_purchase > 0 && (
           <View style={styles.metaRow}>
             <Ionicons name="star" size={14} color={COLORS.gold} />

--- a/apps/mobile/src/hooks/useBrands.ts
+++ b/apps/mobile/src/hooks/useBrands.ts
@@ -13,6 +13,7 @@ function transformToBrand(raw: BrandFromSupabase): Brand {
     logo_url: raw.logo_url,
     description: raw.description,
     points_per_purchase: raw.points_per_purchase,
+    min_purchase_for_points: raw.min_purchase_for_points,
     branches: activeBranches,
     reward_count: raw.rewards?.length ?? 0,
   };
@@ -35,6 +36,7 @@ export function useBrands() {
           logo_url,
           description,
           points_per_purchase,
+          min_purchase_for_points,
           branches (id, name, address, city, phone, is_active),
           rewards!inner (id)
         `,

--- a/apps/mobile/src/hooks/useNotifications.ts
+++ b/apps/mobile/src/hooks/useNotifications.ts
@@ -79,9 +79,13 @@ export function useNotifications() {
         },
         (payload) => {
           const updated = payload.new as Notification;
-          setNotifications((prev) =>
-            prev.map((n) => (n.id === updated.id ? { ...n, ...updated } : n)),
-          );
+          setNotifications((prev) => {
+            const next = prev.map((n) =>
+              n.id === updated.id ? { ...n, ...updated } : n,
+            );
+            setUnreadCount(next.filter((n) => !n.is_read).length);
+            return next;
+          });
         },
       )
       .subscribe();

--- a/apps/mobile/src/types/brands.types.ts
+++ b/apps/mobile/src/types/brands.types.ts
@@ -15,6 +15,7 @@ export interface Brand {
   logo_url: string | null;
   description: string | null;
   points_per_purchase: number | null;
+  min_purchase_for_points: number | null;
   branches: BrandBranch[];
   reward_count: number;
 }
@@ -25,6 +26,7 @@ export interface BrandFromSupabase {
   logo_url: string | null;
   description: string | null;
   points_per_purchase: number | null;
+  min_purchase_for_points: number | null;
   branches: {
     id: string;
     name: string;


### PR DESCRIPTION
…ow min purchase in BrandCard

Recalculate unreadCount from the full notification list in the realtime UPDATE handler so the badge stays in sync when notifications are marked as read. Add min_purchase_for_points to Brand types, query, and display it in BrandCard.