### PR TITLE
fix: increase default points range filter to show all customers

### DIFF
--- a/apps/web/app/dashboard/customers/page.tsx
+++ b/apps/web/app/dashboard/customers/page.tsx
@@ -51,7 +51,7 @@ export default function CustomersPage() {
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
   const [statusFilter, setStatusFilter] = useState('all');
-  const [pointsRange, setPointsRange] = useState<[number, number]>([0, 5000]);
+  const [pointsRange, setPointsRange] = useState<[number, number]>([0, 100000]);
   const [sortBy, setSortBy] = useState('recent');
 
   const handleAddCustomerClick = () => {


### PR DESCRIPTION
The default max was 5000, hiding customers with more points.