### PR TITLE
feat: send staff invite email automatically when creating invite

### DIFF
--- a/apps/web/app/api/staff/send-invite-email/route.ts
+++ b/apps/web/app/api/staff/send-invite-email/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createServerSupabaseClient } from '@/lib/supabase-server';
+import { sendStaffInviteEmail } from '@/lib/email';
+import { z } from 'zod';
+
+const SendInviteEmailSchema = z.object({
+  email: z.string().email(),
+  staffName: z.string().min(1),
+  businessName: z.string().min(1),
+  inviteUrl: z.string().url(),
+  role: z.string().min(1),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const supabase = await createServerSupabaseClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json(
+        { success: false, error: 'Unauthorized' },
+        { status: 401 },
+      );
+    }
+
+    const body = await request.json();
+    const parsed = SendInviteEmailSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        { success: false, error: 'Invalid request body' },
+        { status: 400 },
+      );
+    }
+
+    const { email, staffName, businessName, inviteUrl, role } = parsed.data;
+
+    const result = await sendStaffInviteEmail({
+      to: email,
+      staffName,
+      businessName,
+      inviteUrl,
+      role,
+    });
+
+    return NextResponse.json({
+      success: result.success,
+      error: result.error,
+    });
+  } catch (error) {
+    console.error('Send staff invite email error:', error);
+    return NextResponse.json(
+      { success: false, error: 'Internal server error' },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/components/team/invite-modal.tsx
+++ b/apps/web/components/team/invite-modal.tsx
@@ -41,6 +41,7 @@ export function InviteModal({
   const [error, setError] = useState("");
   const [inviteLink, setInviteLink] = useState("");
   const [copied, setCopied] = useState(false);
+  const [emailSent, setEmailSent] = useState<boolean | null>(null);
 
   // Form fields
   const [name, setName] = useState("");
@@ -105,6 +106,31 @@ export function InviteModal({
       const link = `${window.location.origin}/invite/${invite.token}`;
       setInviteLink(link);
       setState("success");
+
+      // Send invite email (non-blocking)
+      try {
+        const { data: business } = await supabase
+          .from("businesses")
+          .select("name")
+          .eq("id", businessId)
+          .single();
+
+        const res = await fetch("/api/staff/send-invite-email", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            email: email.toLowerCase().trim(),
+            staffName: name.trim(),
+            businessName: business?.name || "Your Business",
+            inviteUrl: link,
+            role: "cashier",
+          }),
+        });
+        const result = await res.json();
+        setEmailSent(result.success);
+      } catch {
+        setEmailSent(false);
+      }
     } catch (err) {
       console.error("Invite creation error:", err);
       setError("Failed to create invite. Please try again.");
@@ -162,8 +188,13 @@ export function InviteModal({
                   <CheckCircle className="w-8 h-8 text-green-500" />
                 </div>
                 <p className="text-gray-500">
-                  Invite created for{" "}
-                  <span className="text-gray-900 font-medium">{name}</span>
+                  {emailSent === true ? (
+                    <>Invite sent to <span className="text-gray-900 font-medium">{email}</span></>
+                  ) : emailSent === false ? (
+                    <>Invite created for <span className="text-gray-900 font-medium">{name}</span> <span className="text-amber-600">(email could not be sent)</span></>
+                  ) : (
+                    <>Invite created for <span className="text-gray-900 font-medium">{name}</span></>
+                  )}
                 </p>
                 {branchName && (
                   <p className="text-gray-500 text-sm">Branch: {branchName}</p>
@@ -200,10 +231,10 @@ export function InviteModal({
                   <AlertCircle className="w-5 h-5 text-amber-500 shrink-0 mt-0.5" />
                   <div className="text-sm">
                     <p className="text-amber-800 font-medium">
-                      Share with your cashier:
+                      {emailSent ? "Email sent! As a backup, you can also:" : "Share with your cashier:"}
                     </p>
                     <ul className="text-amber-700 mt-2 space-y-1">
-                      <li>• The invite link above</li>
+                      <li>• {emailSent ? "Copy and share the invite link above" : "The invite link above"}</li>
                       <li>
                         • They will be able to create their own account and
                         password when they open the link.

--- a/apps/web/lib/email.ts
+++ b/apps/web/lib/email.ts
@@ -46,6 +46,14 @@ interface SendCustomerInviteEmailParams {
   joinUrl: string;
 }
 
+interface SendStaffInviteEmailParams {
+  to: string;
+  staffName: string;
+  businessName: string;
+  inviteUrl: string;
+  role: string;
+}
+
 interface EmailResult {
   success: boolean;
   messageId?: string;
@@ -392,6 +400,94 @@ export async function sendCustomerInviteEmail(
     return { success: true, messageId: data?.id };
   } catch (error) {
     console.error('Send invite email error:', error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    };
+  }
+}
+
+// ============================================
+// STAFF INVITE EMAIL
+// ============================================
+
+export async function sendStaffInviteEmail(
+  params: SendStaffInviteEmailParams,
+): Promise<EmailResult> {
+  try {
+    const { to, staffName, businessName, inviteUrl, role } = params;
+    const resend = getResend();
+
+    const html = `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>You're Invited to Join ${businessName}</title>
+</head>
+<body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background-color: #f5f5f5;">
+  <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="background-color: #f5f5f5;">
+    <tr>
+      <td style="padding: 40px 20px;">
+        <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%" style="max-width: 480px; margin: 0 auto; background-color: #ffffff; border-radius: 16px; overflow: hidden; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);">
+          <tr>
+            <td style="background: linear-gradient(135deg, #5A171E 0%, #751E26 50%, #8B2A33 100%); padding: 24px 32px; text-align: center;">
+              <h1 style="margin: 0; color: #ffffff; font-size: 22px; font-weight: 700;">${businessName}</h1>
+              <p style="margin: 6px 0 0 0; color: rgba(255,255,255,0.85); font-size: 13px;">Team Invitation</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 32px; text-align: center;">
+              <p style="margin: 0 0 8px 0; color: #111827; font-size: 20px; font-weight: 700;">You're Invited!</p>
+              <p style="margin: 0 0 24px 0; color: #4b5563; font-size: 15px; line-height: 1.6;">
+                Hi <strong>${staffName}</strong>, you've been invited to join <strong>${businessName}</strong> as a <strong>${role}</strong> on NoxaLoyalty.
+              </p>
+              <a href="${inviteUrl}" target="_blank" style="display: inline-block; padding: 14px 32px; background: linear-gradient(135deg, #751E26 0%, #8B2A33 100%); color: #ffffff; text-decoration: none; font-size: 16px; font-weight: 600; border-radius: 8px; box-shadow: 0 4px 14px rgba(117, 30, 38, 0.4);">
+                Accept Invitation
+              </a>
+              <p style="margin: 24px 0 0 0; color: #9ca3af; font-size: 13px;">
+                Or copy this link: <a href="${inviteUrl}" style="color: #751E26;">${inviteUrl}</a>
+              </p>
+              <div style="background-color: #f9fafb; border-radius: 8px; padding: 16px; margin-top: 24px; text-align: left;">
+                <p style="margin: 0; color: #4b5563; font-size: 14px; line-height: 1.6;">
+                  Click the link above to create your account and set your password. Once set up, you can log in and start using the system.
+                </p>
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <td style="background-color: #f9fafb; padding: 16px 32px; text-align: center; border-top: 1px solid #e5e7eb;">
+              <p style="margin: 0; color: #9ca3af; font-size: 11px;">
+                Powered by <strong style="color: #751E26;">NoxaLoyalty</strong> &mdash; If you didn't expect this, please ignore this email.
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`.trim();
+
+    const text = `Hi ${staffName}, you've been invited to join ${businessName} as a ${role} on NoxaLoyalty!\n\nAccept your invitation: ${inviteUrl}\n\nClick the link to create your account and set your password.\n\nPowered by NoxaLoyalty`;
+
+    const { data, error } = await resend.emails.send({
+      from: process.env.RESEND_FROM_EMAIL || 'noreply@noxaloyalty.com',
+      to: [to],
+      subject: `You're invited to join ${businessName} on NoxaLoyalty`,
+      html,
+      text,
+    });
+
+    if (error) {
+      console.error('Resend staff invite error:', error);
+      return { success: false, error: error.message };
+    }
+
+    return { success: true, messageId: data?.id };
+  } catch (error) {
+    console.error('Send staff invite email error:', error);
     return {
       success: false,
       error: error instanceof Error ? error.message : 'Unknown error',


### PR DESCRIPTION
Add sendStaffInviteEmail() to email service, create POST endpoint at /api/staff/send-invite-email, and update invite modal to send the email after creating the invite record. Email failure is non-blocking.