### PR TITLE
fix: aggregate points across all businesses for multi-business customers

### DIFF
--- a/apps/mobile/src/hooks/useBrandRewards.ts
+++ b/apps/mobile/src/hooks/useBrandRewards.ts
@@ -23,7 +23,7 @@ interface BrandDetail {
 }
 
 export function useBrandRewards(businessId: string) {
-  const { customer, points, tier, refreshCustomer } = useCustomer();
+  const { customer, points, tier, customerIds, refreshCustomer } = useCustomer();
   const userTier = (isValidTier(tier) ? tier : 'bronze') as TierLevel;
 
   const [brand, setBrand] = useState<BrandDetail | null>(null);
@@ -32,6 +32,21 @@ export function useBrandRewards(businessId: string) {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [redeemingId, setRedeemingId] = useState<string | null>(null);
   const [businessPoints, setBusinessPoints] = useState<number>(0);
+
+  // Find the customer ID linked to this specific business
+  const getCustomerIdForBusiness = useCallback(async (): Promise<string | null> => {
+    if (customerIds.length === 0) return null;
+
+    const { data } = await supabase
+      .from('customer_businesses')
+      .select('customer_id')
+      .in('customer_id', customerIds)
+      .eq('business_id', businessId)
+      .limit(1)
+      .maybeSingle();
+
+    return data?.customer_id ?? customer?.id ?? null;
+  }, [customerIds, businessId, customer?.id]);
 
   const fetchBrandData = useCallback(async (): Promise<void> => {
     try {
@@ -81,16 +96,16 @@ export function useBrandRewards(businessId: string) {
         rewardsQuery,
       ]);
 
-      // Fetch per-business points balance
-      if (customer?.id) {
-        const { data: cbRow } = await supabase
+      // Fetch per-business points balance across all customer records
+      if (customerIds.length > 0) {
+        const { data: cbRows } = await supabase
           .from('customer_businesses')
           .select('points')
-          .eq('customer_id', customer.id)
-          .eq('business_id', businessId)
-          .maybeSingle();
+          .in('customer_id', customerIds)
+          .eq('business_id', businessId);
 
-        setBusinessPoints(cbRow?.points ?? 0);
+        const total = (cbRows ?? []).reduce((sum, row) => sum + (row.points ?? 0), 0);
+        setBusinessPoints(total);
       }
 
       if (brandResult.error) throw new Error(brandResult.error.message);
@@ -119,7 +134,7 @@ export function useBrandRewards(businessId: string) {
       setIsLoading(false);
       setIsRefreshing(false);
     }
-  }, [businessId, customer?.id]);
+  }, [businessId, customerIds]);
 
   useEffect(() => {
     fetchBrandData();
@@ -168,10 +183,13 @@ export function useBrandRewards(businessId: string) {
       try {
         setRedeemingId(reward.id);
 
+        // Use the customer ID linked to this business for correct redemption
+        const customerId = await getCustomerIdForBusiness() ?? customer.id;
+
         const { data, error: redeemError } = await supabase.rpc(
           'redeem_reward',
           {
-            p_customer_id: customer.id,
+            p_customer_id: customerId,
             p_reward_id: reward.id,
           },
         );
@@ -182,14 +200,11 @@ export function useBrandRewards(businessId: string) {
         if (!result.success)
           throw new Error(result.error ?? 'Redemption failed');
 
-        // Note: per-business points are deducted automatically by
-        // the trg_auto_link_customer_business trigger when redeem_reward inserts a transaction
-
         await Promise.all([refreshCustomer(), fetchBrandData()]);
 
         return {
           id: result.redemption_id,
-          customer_id: customer.id,
+          customer_id: customerId,
           reward_id: reward.id,
           business_id: reward.business_id,
           points_used: result.points_used,
@@ -203,7 +218,7 @@ export function useBrandRewards(businessId: string) {
         setRedeemingId(null);
       }
     },
-    [customer, canRedeem, refreshCustomer, fetchBrandData, businessId],
+    [customer, canRedeem, getCustomerIdForBusiness, refreshCustomer, fetchBrandData],
   );
 
   const refresh = useCallback(async (): Promise<void> => {

--- a/apps/mobile/src/hooks/useCustomer.ts
+++ b/apps/mobile/src/hooks/useCustomer.ts
@@ -1,58 +1,21 @@
 // src/hooks/useCustomer.ts
 
-import { useEffect, useState, useCallback } from 'react';
 import { useAuth } from './useAuth';
-import { supabase } from '../lib/supabase';
 import { getTier, getNextTier, getProgressToNextTier } from '../lib/constants';
 import type { TierLevel } from '../types/rewards.types';
-import { Customer } from '@/src/types/database.types';
 
 export function useCustomer() {
-  const { customer: authCustomer, refreshCustomer } = useAuth();
+  const {
+    customer,
+    totalPoints,
+    lifetimePoints: authLifetimePoints,
+    customerIds,
+    refreshCustomer,
+  } = useAuth();
 
-  // Local state for real-time updates
-  const [customer, setCustomer] = useState(authCustomer);
-
-  // Sync with auth customer
-  useEffect(() => {
-    setCustomer(authCustomer);
-  }, [authCustomer]);
-
-  // Real-time subscription for customer updates
-  useEffect(() => {
-    if (!authCustomer?.id) return;
-
-    const channel = supabase
-      .channel(`customer-${authCustomer.id}`)
-      .on(
-        'postgres_changes',
-        {
-          event: 'UPDATE',
-          schema: 'public',
-          table: 'customers',
-          filter: `id=eq.${authCustomer.id}`,
-        },
-        (payload) => {
-          setCustomer((prev) => {
-            if (!prev) return payload.new as Customer;
-
-            return {
-              ...prev,
-              ...payload.new,
-            } as Customer;
-          });
-        },
-      )
-      .subscribe();
-
-    return () => {
-      supabase.removeChannel(channel);
-    };
-  }, [authCustomer?.id]);
-
-  // Extract values with defaults
-  const points = customer?.total_points ?? 0;
-  const lifetimePoints = customer?.lifetime_points ?? 0;
+  // Use aggregated points from AuthProvider (sum across all businesses)
+  const points = totalPoints;
+  const lifetimePoints = authLifetimePoints;
   const tier = (customer?.tier as TierLevel) ?? 'bronze';
 
   // Calculate tier info using lifetime points
@@ -70,6 +33,7 @@ export function useCustomer() {
     nextTier,
     tierProgress,
     lastVisit: customer?.last_visit ?? null,
+    customerIds,
     refreshCustomer,
   };
 }

--- a/apps/mobile/src/hooks/useWallet.ts
+++ b/apps/mobile/src/hooks/useWallet.ts
@@ -275,13 +275,12 @@ const TRANSACTION_LIMIT = 50;
 // ============================================
 
 export function useWallet() {
-  const { customer, points } = useCustomer();
+  const { customer, points, lifetimePoints, customerIds } = useCustomer();
 
   // State
   const [activeTab, setActiveTab] = useState<WalletTab>('transactions');
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [redemptions, setRedemptions] = useState<CustomerRedemption[]>([]);
-  const [lifetimePoints, setLifetimePoints] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [error, setError] = useState<Error | null>(null);
@@ -291,11 +290,11 @@ export function useWallet() {
   // ============================================
 
   const fetchTransactions = useCallback(
-    async (customerId: string): Promise<Transaction[]> => {
+    async (ids: string[]): Promise<Transaction[]> => {
       const { data, error } = await supabase
         .from('transactions')
         .select(TRANSACTION_SELECT)
-        .eq('customer_id', customerId)
+        .in('customer_id', ids)
         .order('created_at', { ascending: false })
         .limit(TRANSACTION_LIMIT);
 
@@ -307,11 +306,11 @@ export function useWallet() {
   );
 
   const fetchRedemptions = useCallback(
-    async (customerId: string): Promise<CustomerRedemption[]> => {
+    async (ids: string[]): Promise<CustomerRedemption[]> => {
       const { data, error } = await supabase
         .from('redemptions')
         .select(REDEMPTION_SELECT)
-        .eq('customer_id', customerId)
+        .in('customer_id', ids)
         .order('created_at', { ascending: false });
 
       if (error) throw error;
@@ -321,36 +320,19 @@ export function useWallet() {
     []
   );
 
-  const fetchLifetimePoints = useCallback(
-    async (customerId: string): Promise<number> => {
-      const { data, error } = await supabase
-        .from('customers')
-        .select('lifetime_points')
-        .eq('id', customerId)
-        .single();
-
-      if (error) throw error;
-
-      return (data as { lifetime_points: number | null })?.lifetime_points ?? 0;
-    },
-    []
-  );
-
   const fetchAllData = useCallback(async () => {
-    if (!customer?.id) return;
+    if (customerIds.length === 0) return;
 
     try {
       setError(null);
 
-      const [txData, redemptionData, lifetime] = await Promise.all([
-        fetchTransactions(customer.id),
-        fetchRedemptions(customer.id),
-        fetchLifetimePoints(customer.id),
+      const [txData, redemptionData] = await Promise.all([
+        fetchTransactions(customerIds),
+        fetchRedemptions(customerIds),
       ]);
 
       setTransactions(txData);
       setRedemptions(redemptionData);
-      setLifetimePoints(lifetime);
     } catch (err) {
       console.error('Wallet fetch error:', err);
       setError(
@@ -360,7 +342,7 @@ export function useWallet() {
       setIsLoading(false);
       setIsRefreshing(false);
     }
-  }, [customer?.id, fetchTransactions, fetchRedemptions, fetchLifetimePoints]);
+  }, [customerIds, fetchTransactions, fetchRedemptions]);
 
   // ============================================
   // EFFECTS
@@ -368,35 +350,37 @@ export function useWallet() {
 
   // Initial fetch
   useEffect(() => {
-    if (customer?.id) {
+    if (customerIds.length > 0) {
       fetchAllData();
     }
-  }, [customer?.id, fetchAllData]);
+  }, [customerIds, fetchAllData]);
 
-  // Realtime subscription for new transactions
+  // Realtime subscription for new transactions across all customer records
   useEffect(() => {
-    if (!customer?.id) return;
+    if (customerIds.length === 0) return;
 
-    const channel = supabase
-      .channel(`wallet-${customer.id}`)
-      .on(
-        'postgres_changes',
-        {
-          event: 'INSERT',
-          schema: 'public',
-          table: 'transactions',
-          filter: `customer_id=eq.${customer.id}`,
-        },
-        () => {
-          fetchAllData();
-        }
-      )
-      .subscribe();
+    const channels = customerIds.map((id) =>
+      supabase
+        .channel(`wallet-${id}`)
+        .on(
+          'postgres_changes',
+          {
+            event: 'INSERT',
+            schema: 'public',
+            table: 'transactions',
+            filter: `customer_id=eq.${id}`,
+          },
+          () => {
+            fetchAllData();
+          }
+        )
+        .subscribe()
+    );
 
     return () => {
-      supabase.removeChannel(channel);
+      channels.forEach((ch) => supabase.removeChannel(ch));
     };
-  }, [customer?.id, fetchAllData]);
+  }, [customerIds, fetchAllData]);
 
   // ============================================
   // HANDLERS

--- a/apps/mobile/src/providers/AuthProvider.tsx
+++ b/apps/mobile/src/providers/AuthProvider.tsx
@@ -29,6 +29,9 @@ interface AuthState {
   isInitialized: boolean;
   isNewCustomer: boolean;
   needsPhone: boolean;
+  totalPoints: number;
+  lifetimePoints: number;
+  customerIds: string[];
 }
 
 interface AuthContextType extends AuthState {
@@ -48,6 +51,9 @@ const initialState: AuthState = {
   isInitialized: false,
   isNewCustomer: false,
   needsPhone: false,
+  totalPoints: 0,
+  lifetimePoints: 0,
+  customerIds: [],
 };
 
 const PHONE_PROMPT_SKIP_KEY = 'phone_prompt_skip_count';
@@ -110,6 +116,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         const { customer, isNew } =
           await customerService.findOrCreate(profile);
 
+        // Fetch all customer IDs and aggregate points across all businesses
+        const [aggregated, customerIds] = await Promise.all([
+          customerService.getAggregatedPoints(user.id),
+          customerService.getAllCustomerIds(user.id),
+        ]);
+
         // Check if phone prompt should be shown
         let needsPhone = false;
         if (customer && !customer.phone) {
@@ -127,10 +139,13 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           // Only show onboarding modal for fresh signups, not app relaunches
           isNewCustomer: fromInit ? false : isNew,
           needsPhone,
+          totalPoints: aggregated.totalPoints,
+          lifetimePoints: aggregated.lifetimePoints,
+          customerIds,
         });
 
         if (customer?.id) {
-          setupRealtimeSubscription(customer.id);
+          setupRealtimeSubscription(user.id);
 
           // Register push token (non-blocking)
           notificationService.registerPushToken(customer.id).then((token) => {
@@ -147,6 +162,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           isInitialized: true,
           isNewCustomer: false,
           needsPhone: false,
+          totalPoints: 0,
+          lifetimePoints: 0,
+          customerIds: [],
         });
       } finally {
         isLoadingCustomer.current = false;
@@ -155,33 +173,29 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     [],
   );
 
-  // Setup realtime subscription for customer points updates
-  const setupRealtimeSubscription = useCallback((customerId: string) => {
+  // Setup realtime subscription for customer points updates (all records for user)
+  const setupRealtimeSubscription = useCallback((userId: string) => {
     if (realtimeChannelRef.current) {
       supabase.removeChannel(realtimeChannelRef.current);
     }
 
-    const channel = supabase.channel(`customer-${customerId}`).on(
+    const channel = supabase.channel(`customer-user-${userId}`).on(
       'postgres_changes',
       {
         event: 'UPDATE',
         schema: 'public',
         table: 'customers',
-        filter: `id=eq.${customerId}`,
+        filter: `user_id=eq.${userId}`,
       },
-      (payload) => {
-        setState((prev) => ({
-          ...prev,
-          customer: prev.customer
-            ? {
-                ...prev.customer,
-                total_points: (payload.new as Customer).total_points,
-                lifetime_points: (payload.new as Customer).lifetime_points,
-                tier: (payload.new as Customer).tier,
-                last_visit: (payload.new as Customer).last_visit,
-              }
-            : null,
-        }));
+      () => {
+        // Re-aggregate points from all customer records
+        customerService.getAggregatedPoints(userId).then((aggregated) => {
+          setState((prev) => ({
+            ...prev,
+            totalPoints: aggregated.totalPoints,
+            lifetimePoints: aggregated.lifetimePoints,
+          }));
+        });
       },
     );
 
@@ -237,6 +251,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
           isInitialized: true,
           isNewCustomer: false,
           needsPhone: false,
+          totalPoints: 0,
+          lifetimePoints: 0,
+          customerIds: [],
         });
       }
     });
@@ -314,6 +331,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         isInitialized: true,
         isNewCustomer: false,
         needsPhone: false,
+        totalPoints: 0,
+        lifetimePoints: 0,
+        customerIds: [],
       });
     }
   }, [cleanupRealtimeSubscription, state.customer?.id]);
@@ -345,8 +365,18 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     if (!state.user) return;
 
     try {
-      const customer = await customerService.getByUserId(state.user.id);
-      setState((prev) => ({ ...prev, customer }));
+      const [customer, aggregated, customerIds] = await Promise.all([
+        customerService.getByUserId(state.user.id),
+        customerService.getAggregatedPoints(state.user.id),
+        customerService.getAllCustomerIds(state.user.id),
+      ]);
+      setState((prev) => ({
+        ...prev,
+        customer,
+        totalPoints: aggregated.totalPoints,
+        lifetimePoints: aggregated.lifetimePoints,
+        customerIds,
+      }));
     } catch (error) {
       console.error('[AuthProvider] Refresh customer error:', error);
     }

--- a/apps/mobile/src/services/customer.service.ts
+++ b/apps/mobile/src/services/customer.service.ts
@@ -29,6 +29,11 @@ const CUSTOMER_COLUMNS = `
 // TYPES
 // ============================================
 
+export interface AggregatedPoints {
+  totalPoints: number;
+  lifetimePoints: number;
+}
+
 interface UserProfile {
   id: string;
   email?: string;
@@ -240,6 +245,43 @@ export const customerService = {
       console.error('[CustomerService] updatePhone error:', error.message);
       throw error;
     }
+  },
+
+  /**
+   * Get all customer IDs for a user (one per business)
+   */
+  async getAllCustomerIds(userId: string): Promise<string[]> {
+    const { data, error } = await supabase
+      .from('customers')
+      .select('id')
+      .eq('user_id', userId);
+
+    if (error) {
+      console.error('[CustomerService] getAllCustomerIds error:', error.message);
+      throw error;
+    }
+
+    return (data ?? []).map((row) => row.id);
+  },
+
+  /**
+   * Get aggregated points across all businesses for a user
+   */
+  async getAggregatedPoints(userId: string): Promise<AggregatedPoints> {
+    const { data, error } = await supabase
+      .from('customers')
+      .select('total_points, lifetime_points')
+      .eq('user_id', userId);
+
+    if (error) {
+      console.error('[CustomerService] getAggregatedPoints error:', error.message);
+      throw error;
+    }
+
+    const totalPoints = (data ?? []).reduce((sum, row) => sum + (row.total_points ?? 0), 0);
+    const lifetimePoints = (data ?? []).reduce((sum, row) => sum + (row.lifetime_points ?? 0), 0);
+
+    return { totalPoints, lifetimePoints };
   },
 
   /**

--- a/apps/web/lib/services/pos.service.ts
+++ b/apps/web/lib/services/pos.service.ts
@@ -871,12 +871,13 @@ export async function createStaffSale(
     transaction_amount: totalCentavos / 100,
   });
 
-  // 12. Get updated customer balance
-  const { data: updatedCustomer } = await supabase
-    .from("customers")
-    .select("total_points")
-    .eq("id", input.customer_id)
-    .single();
+  // 12. Get updated per-business points balance
+  const { data: businessBalance } = await supabase
+    .from("customer_businesses")
+    .select("points")
+    .eq("customer_id", input.customer_id)
+    .eq("business_id", businessId)
+    .maybeSingle();
 
   return {
     sale_id: sale.id,
@@ -887,7 +888,7 @@ export async function createStaffSale(
     total_centavos: totalCentavos,
     points_earned: pointsEarned,
     points_redeemed: exchangePoints,
-    new_points_balance: updatedCustomer?.total_points || 0,
+    new_points_balance: businessBalance?.points || 0,
     tier_multiplier: tierMultiplier,
     base_points: basePoints,
   };


### PR DESCRIPTION
Users with customer records at multiple businesses saw incorrect points after pull-to-refresh because getByUserId returned only one record. Now aggregates points across all customer records, queries transactions and redemptions across all customer IDs, and shows per-business balance in POS receipt instead of global total.