### PR TITLE
fix: staff blank screen after redemption and mobile reward sync

### DIFF
--- a/apps/mobile/src/components/home/RedeemableRewards.tsx
+++ b/apps/mobile/src/components/home/RedeemableRewards.tsx
@@ -93,6 +93,7 @@ export function RedeemableRewards() {
 const styles = StyleSheet.create({
   container: {
     marginTop: SPACING.lg,
+    marginBottom: SPACING.xl,
   },
   title: {
     fontSize: FONT_SIZE.lg,

--- a/apps/mobile/src/hooks/useWallet.ts
+++ b/apps/mobile/src/hooks/useWallet.ts
@@ -359,9 +359,9 @@ export function useWallet() {
   useEffect(() => {
     if (customerIds.length === 0) return;
 
-    const channels = customerIds.map((id) =>
+    const channels = customerIds.flatMap((id) => [
       supabase
-        .channel(`wallet-${id}`)
+        .channel(`wallet-tx-${id}`)
         .on(
           'postgres_changes',
           {
@@ -374,8 +374,23 @@ export function useWallet() {
             fetchAllData();
           }
         )
-        .subscribe()
-    );
+        .subscribe(),
+      supabase
+        .channel(`wallet-redemptions-${id}`)
+        .on(
+          'postgres_changes',
+          {
+            event: 'UPDATE',
+            schema: 'public',
+            table: 'redemptions',
+            filter: `customer_id=eq.${id}`,
+          },
+          () => {
+            fetchAllData();
+          }
+        )
+        .subscribe(),
+    ]);
 
     return () => {
       channels.forEach((ch) => supabase.removeChannel(ch));

--- a/apps/web/app/staff/page.tsx
+++ b/apps/web/app/staff/page.tsx
@@ -596,7 +596,7 @@ export default function StaffScannerPage() {
       tier_multiplier: 1,
       base_points: pointsUsed,
     });
-    setScannerState("success");
+    resetScanner();
   };
 
   // ============================================


### PR DESCRIPTION
- Staff page now resets to idle state after redemption instead of setting unrendered "success" state that caused blank screen
- Mobile wallet subscribes to redemption UPDATE events so completed rewards move out of "Active" in real-time
- Add bottom margin to RedeemableRewards for better spacing