### PR TITLE
feat: cache public business endpoints (5min TTL)

### DIFF
--- a/apps/web/app/api/public/business/[slug]/rewards/route.ts
+++ b/apps/web/app/api/public/business/[slug]/rewards/route.ts
@@ -3,6 +3,7 @@ import {
   getBusinessBySlug,
   getPublicRewards,
 } from '@/lib/services/public-business.service';
+import { cacheGet, CacheKeys, CacheTTL } from '@/lib/cache';
 
 interface RouteParams {
   params: Promise<{ slug: string }>;
@@ -12,7 +13,11 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   try {
     const { slug } = await params;
 
-    const business = await getBusinessBySlug(slug);
+    const business = await cacheGet(
+      CacheKeys.business(slug),
+      () => getBusinessBySlug(slug),
+      { ttlSeconds: CacheTTL.business },
+    );
 
     if (!business) {
       return NextResponse.json(
@@ -21,7 +26,11 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       );
     }
 
-    const rewards = await getPublicRewards(business.id);
+    const rewards = await cacheGet(
+      CacheKeys.rewards(business.id),
+      () => getPublicRewards(business.id),
+      { ttlSeconds: CacheTTL.rewards },
+    );
 
     return NextResponse.json({
       success: true,

--- a/apps/web/app/api/public/business/[slug]/route.ts
+++ b/apps/web/app/api/public/business/[slug]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getBusinessBySlug } from '@/lib/services/public-business.service';
+import { cacheGet, CacheKeys, CacheTTL } from '@/lib/cache';
 
 interface RouteParams {
   params: Promise<{ slug: string }>;
@@ -9,7 +10,11 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   try {
     const { slug } = await params;
 
-    const business = await getBusinessBySlug(slug);
+    const business = await cacheGet(
+      CacheKeys.business(slug),
+      () => getBusinessBySlug(slug),
+      { ttlSeconds: CacheTTL.business },
+    );
 
     if (!business) {
       return NextResponse.json(

--- a/apps/web/lib/cache.ts
+++ b/apps/web/lib/cache.ts
@@ -73,12 +73,14 @@ export async function cacheInvalidatePrefix(prefix: string): Promise<void> {
 // ============================================
 
 export const CacheKeys = {
+  business: (slug: string) => `business:slug:${slug}`,
   rewards: (businessId: string) => `rewards:${businessId}`,
   points: (customerId: string) => `points:${customerId}`,
   leaderboard: (businessId: string) => `leaderboard:${businessId}`,
 };
 
 export const CacheTTL = {
+  business: 300,     // 5 minutes — business profile changes rarely
   rewards: 300,      // 5 minutes
   points: 10,        // 10 seconds
   leaderboard: 60,   // 1 minute

--- a/docs/superpowers/plans/2026-05-19-cache-public-business-endpoints.md
+++ b/docs/superpowers/plans/2026-05-19-cache-public-business-endpoints.md
@@ -1,0 +1,373 @@
+# Cache Public Business Endpoints Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the existing Redis cache helper into the two highest-traffic public business GET endpoints so repeated requests within a 5-minute window serve from Redis instead of Supabase.
+
+**Architecture:** TTL-only cache-aside using the existing `cacheGet` helper in `apps/web/lib/cache.ts`. Adds one new cache key (`business:slug:<slug>`), reuses the existing `rewards:<businessId>` key, and wraps the service calls in two route handlers. No new infrastructure, no changes to dashboard write paths, no active invalidation.
+
+**Tech Stack:** Next.js 16 App Router route handlers, Upstash Redis (already configured via `lib/redis.ts`), TypeScript.
+
+**Spec:** `docs/superpowers/specs/2026-05-19-cache-public-business-endpoints-design.md`
+
+**Branch:** `feat/cache-public-business-endpoints` (already created off `dev`)
+
+**Note on testing:** No automated test framework is configured in this project (per `CLAUDE.md`). This plan uses `npm run lint` + `npm run typecheck` for static verification at each step and a manual verification task at the end. We do **not** add a test framework as part of this change — that is a separate decision out of scope.
+
+**Note on commit messages:** User memory specifies no `Co-Authored-By` trailer. Use plain conventional-commit messages. Recent repo convention uses `feat(scope):` / `fix(scope):` / `chore(scope):` / `docs(scope):`.
+
+---
+
+## File Structure
+
+**Modify:**
+- `apps/web/lib/cache.ts` — add `CacheKeys.business(slug)` and `CacheTTL.business`.
+- `apps/web/app/api/public/business/[slug]/route.ts` — wrap `getBusinessBySlug(slug)` call with `cacheGet`.
+- `apps/web/app/api/public/business/[slug]/rewards/route.ts` — wrap both the `getBusinessBySlug(slug)` lookup and the `getPublicRewards(business.id)` call with `cacheGet`.
+
+**Do not modify:**
+- `apps/web/lib/redis.ts` — already wired correctly.
+- `apps/web/lib/services/public-business.service.ts` — caching is layered at the route, not the service.
+- `apps/web/app/api/public/business/[slug]/lookup/route.ts` — PIN-auth, customer-specific, never cached.
+- Dashboard pages — out of scope (no active invalidation in this PR).
+
+---
+
+## Task 1: Add `business` cache key and TTL
+
+**Files:**
+- Modify: `apps/web/lib/cache.ts:75-86`
+
+- [ ] **Step 1: Add the business key to `CacheKeys`**
+
+Open `apps/web/lib/cache.ts`. Replace the `CacheKeys` and `CacheTTL` objects (currently lines 75–86) with:
+
+```ts
+export const CacheKeys = {
+  business: (slug: string) => `business:slug:${slug}`,
+  rewards: (businessId: string) => `rewards:${businessId}`,
+  points: (customerId: string) => `points:${customerId}`,
+  leaderboard: (businessId: string) => `leaderboard:${businessId}`,
+};
+
+export const CacheTTL = {
+  business: 300,     // 5 minutes — business profile changes rarely
+  rewards: 300,      // 5 minutes
+  points: 10,        // 10 seconds
+  leaderboard: 60,   // 1 minute
+};
+```
+
+- [ ] **Step 2: Run lint + typecheck**
+
+From `apps/web`:
+
+```bash
+npm run lint
+npm run typecheck
+```
+
+Expected: both exit 0. No new errors introduced.
+
+If `tsc` complains about unused exports, ignore — the new `business` key is consumed in Tasks 2 and 3.
+
+- [ ] **Step 3: Commit**
+
+From the repo root:
+
+```bash
+git add apps/web/lib/cache.ts
+git commit -m "feat(cache): add business profile cache key and TTL"
+```
+
+Verify with `git status` — only `apps/web/lib/cache.ts` should be in the new commit. The pre-existing untracked files (`NoxaLoyalty-Proposal.html`, `app.json`, `apps/web/public/Business-logo/`, etc.) and pre-existing modifications to `.gitignore`, `apps/mobile/app.json`, `apps/web/.claude/settings.local.json` must remain untouched and out of this commit.
+
+---
+
+## Task 2: Cache the business profile endpoint
+
+**Files:**
+- Modify: `apps/web/app/api/public/business/[slug]/route.ts`
+
+- [ ] **Step 1: Replace the route file**
+
+The file is small (32 lines). Replace its full contents with:
+
+```ts
+import { NextRequest, NextResponse } from 'next/server';
+import { getBusinessBySlug } from '@/lib/services/public-business.service';
+import { cacheGet, CacheKeys, CacheTTL } from '@/lib/cache';
+
+interface RouteParams {
+  params: Promise<{ slug: string }>;
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  try {
+    const { slug } = await params;
+
+    const business = await cacheGet(
+      CacheKeys.business(slug),
+      () => getBusinessBySlug(slug),
+      { ttlSeconds: CacheTTL.business },
+    );
+
+    if (!business) {
+      return NextResponse.json(
+        { success: false, error: 'Business not found' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      data: business,
+    });
+  } catch (error) {
+    console.error('Error fetching business:', error);
+    return NextResponse.json(
+      { success: false, error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}
+```
+
+Behavior is identical for the consumer. The only change: the `getBusinessBySlug(slug)` call is now wrapped by `cacheGet`, which also caches `null` results (intentional — see spec §"Error Handling").
+
+- [ ] **Step 2: Run lint + typecheck**
+
+From `apps/web`:
+
+```bash
+npm run lint
+npm run typecheck
+```
+
+Expected: both exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/app/api/public/business/[slug]/route.ts
+git commit -m "feat(cache): cache GET /api/public/business/[slug] with 5min TTL"
+```
+
+---
+
+## Task 3: Cache the rewards endpoint
+
+**Files:**
+- Modify: `apps/web/app/api/public/business/[slug]/rewards/route.ts`
+
+- [ ] **Step 1: Replace the route file**
+
+The file is small (37 lines). Replace its full contents with:
+
+```ts
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  getBusinessBySlug,
+  getPublicRewards,
+} from '@/lib/services/public-business.service';
+import { cacheGet, CacheKeys, CacheTTL } from '@/lib/cache';
+
+interface RouteParams {
+  params: Promise<{ slug: string }>;
+}
+
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  try {
+    const { slug } = await params;
+
+    const business = await cacheGet(
+      CacheKeys.business(slug),
+      () => getBusinessBySlug(slug),
+      { ttlSeconds: CacheTTL.business },
+    );
+
+    if (!business) {
+      return NextResponse.json(
+        { success: false, error: 'Business not found' },
+        { status: 404 }
+      );
+    }
+
+    const rewards = await cacheGet(
+      CacheKeys.rewards(business.id),
+      () => getPublicRewards(business.id),
+      { ttlSeconds: CacheTTL.rewards },
+    );
+
+    return NextResponse.json({
+      success: true,
+      data: rewards,
+    });
+  } catch (error) {
+    console.error('Error fetching rewards:', error);
+    return NextResponse.json(
+      { success: false, error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}
+```
+
+Notes:
+- The `business` lookup at the top reuses the same `CacheKeys.business(slug)` key Task 2 introduced — first hit on either endpoint warms the cache for the other.
+- Behavior is identical for the consumer.
+
+- [ ] **Step 2: Run lint + typecheck**
+
+From `apps/web`:
+
+```bash
+npm run lint
+npm run typecheck
+```
+
+Expected: both exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add "apps/web/app/api/public/business/[slug]/rewards/route.ts"
+git commit -m "feat(cache): cache GET /api/public/business/[slug]/rewards with 5min TTL"
+```
+
+(The path has square brackets; the quotes are required on PowerShell to avoid glob expansion.)
+
+---
+
+## Task 4: Manual verification
+
+This task is verification only — no commits, no code.
+
+**Prereqs:**
+- `apps/web/.env.local` must include `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN`. If they are missing the cache is a no-op (graceful fallback) — endpoints still work but verification steps 1–4 will not show cache behavior. Confirm both variables are present before continuing, or skip to step 5.
+- A known public business slug exists in the database. Pick any active business and note its slug.
+
+- [ ] **Step 1: Cold-cache request (business endpoint)**
+
+Start the dev server:
+
+```bash
+npm run dev:web
+```
+
+In a new terminal, hit the business endpoint twice with `curl` and time it:
+
+```bash
+curl -w "\nTime: %{time_total}s\n" http://localhost:3000/api/public/business/<slug>
+curl -w "\nTime: %{time_total}s\n" http://localhost:3000/api/public/business/<slug>
+```
+
+Expected: first call shows ~100–300ms `Time:`; second call shows ~10–50ms `Time:` (faster).
+
+- [ ] **Step 2: Cold-cache request (rewards endpoint)**
+
+```bash
+curl -w "\nTime: %{time_total}s\n" http://localhost:3000/api/public/business/<slug>/rewards
+curl -w "\nTime: %{time_total}s\n" http://localhost:3000/api/public/business/<slug>/rewards
+```
+
+Expected: second call faster than the first.
+
+- [ ] **Step 3: Verify keys in Upstash dashboard**
+
+Log into the Upstash console and open the Redis instance dev points to. Confirm these keys exist:
+
+- `business:slug:<your-slug>` — value should be a JSON object matching `PublicBusiness`.
+- `rewards:<business-id>` — value should be a JSON array of rewards.
+
+Both should show a TTL counting down from ~300 seconds.
+
+- [ ] **Step 4: TTL expiry**
+
+Wait 5+ minutes (or, faster: delete the `business:slug:<slug>` key manually from the Upstash dashboard). Hit the endpoint again; confirm it's slow again (cache miss → DB → repopulate).
+
+- [ ] **Step 5: No-Redis fallback**
+
+Stop the dev server. Temporarily comment out `UPSTASH_REDIS_REST_URL` in `apps/web/.env.local`. Restart the dev server. Hit both endpoints — they should still return correct data. Console should log `Upstash Redis not configured — falling back to no-op` once on first call.
+
+Restore the env var when done and restart the server.
+
+- [ ] **Step 6: 404 behavior (negative results are NOT cached)**
+
+```bash
+curl -w "\nHTTP %{http_code}\n" http://localhost:3000/api/public/business/this-slug-does-not-exist
+curl -w "\nHTTP %{http_code}\n" http://localhost:3000/api/public/business/this-slug-does-not-exist
+```
+
+Both return `HTTP 404`. In Upstash, confirm **no** `business:slug:this-slug-does-not-exist` key appears — `cacheGet`'s hit-check excludes `null`, so negative results are not cached. Both calls touch Supabase. This is the documented behavior in the spec (§Error Handling). Negative caching is deferred to a future PR.
+
+- [ ] **Step 7: Stale-data sanity check**
+
+While the cache is warm, open the dashboard and edit the business's logo (or any cached field). Hit the public endpoint immediately — you'll see the **old** value. Wait ~5 minutes (or manually delete the key in Upstash) — the new value appears. This is the expected tradeoff documented in the spec.
+
+---
+
+## Task 5: Push and open PR
+
+- [ ] **Step 1: Fetch latest dev**
+
+```bash
+git fetch origin
+```
+
+- [ ] **Step 2: Merge latest `dev` into the feature branch**
+
+```bash
+git merge origin/dev
+```
+
+If your collaborator pushed nothing, this is a no-op. If they pushed unrelated changes, the merge fast-forwards or creates a clean merge commit. If they touched any of the same files (`lib/cache.ts` or the two route files), resolve conflicts file-by-file — prefer their changes for unrelated edits, layer the caching on top.
+
+After resolving any conflicts, re-run `npm run lint` and `npm run typecheck` to confirm the merged state still compiles.
+
+- [ ] **Step 3: Push the branch**
+
+```bash
+git push -u origin feat/cache-public-business-endpoints
+```
+
+- [ ] **Step 4: Open PR via gh CLI**
+
+```bash
+gh pr create --base dev --title "feat: cache public business endpoints (5min TTL)" --body "$(cat <<'EOF'
+## Summary
+- Wire existing `cacheGet` helper into `/api/public/business/[slug]` and `/api/public/business/[slug]/rewards`
+- Add `CacheKeys.business(slug)` and `CacheTTL.business = 300` to `lib/cache.ts`
+- TTL-only invalidation (5 min); no active invalidation hooks in this PR
+
+## Spec
+`docs/superpowers/specs/2026-05-19-cache-public-business-endpoints-design.md`
+
+## Why
+These two endpoints are hit on every customer QR scan and customer-facing page load. Business profile and rewards catalog change on the order of days. Caching for 5 minutes eliminates the vast majority of DB queries during traffic spikes.
+
+## Out of scope
+- Active invalidation from dashboard write paths (deferred — dashboards write directly to Supabase from the browser today)
+- Caching the PIN-auth `lookup` endpoint (per-customer, security-sensitive)
+- Rate limiting on the GET endpoints (separate PR)
+
+## Test plan
+- [ ] Hit each cached endpoint twice from the browser/curl; second call is faster
+- [ ] Confirm `business:slug:<slug>` and `rewards:<id>` keys appear in Upstash dashboard with ~300s TTL
+- [ ] Confirm the endpoints still return correct data when Redis env vars are unset (graceful no-op)
+- [ ] Confirm a 404 for a nonexistent slug is also cached (DB protection)
+- [ ] Confirm dashboard edits propagate to customer side within 5 minutes
+EOF
+)"
+```
+
+This opens a PR against `dev`. Your collaborator can review and merge from GitHub.
+
+---
+
+## Self-Review (already run)
+
+- **Spec coverage:** every section of the spec maps to a task. Cache key change → Task 1. Business endpoint → Task 2. Rewards endpoint → Task 3. Data flow, error handling, 404 caching, stale-data check, no-Redis fallback → Task 4. Branch + PR workflow → Task 5.
+- **Placeholder scan:** no TBD / TODO / "implement later" / vague instructions. Every code step shows the full code.
+- **Type consistency:** `CacheKeys.business(slug)` and `CacheTTL.business` are defined in Task 1 and consumed identically in Tasks 2 and 3. `getBusinessBySlug` return type (`PublicBusiness | null`) is the same shape `cacheGet` will store and return.
+- **YAGNI:** no test framework added, no invalidation infra added, no rate-limit work pulled in.

--- a/docs/superpowers/specs/2026-05-19-cache-public-business-endpoints-design.md
+++ b/docs/superpowers/specs/2026-05-19-cache-public-business-endpoints-design.md
@@ -132,13 +132,13 @@ This is already implemented in `cacheGet`. No new code needed.
 |---|---|
 | `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` env vars missing | `getRedis()` returns `null` → `cacheGet` calls the fetcher directly. Endpoints work normally with no caching. |
 | Redis is configured but errors mid-request (network blip, Upstash outage) | Exception propagates out of `cacheGet` and is caught by the route's existing `try/catch`, which returns a 500. Sentry captures the error. **Acceptable** — Redis outages are rare, and we want visibility, not silent fallback. |
-| Fetcher (Supabase) returns `null` (business not found) | `null` is stored in Redis with the same TTL. Subsequent requests for the same slug return 404 without hitting the DB. Prevents a typo'd slug from DoS-ing the DB. **Tradeoff:** if a real business is created with that slug within 5 minutes, customers see 404 until the cached `null` expires. Accepted — slug creation is rare. |
+| Fetcher (Supabase) returns `null` (business not found) | `null` propagates back to the route, which returns 404. The `null` is **not** cached — `cacheGet`'s hit-check is `cached !== null && cached !== undefined`, so a stored `null` falls through to the fetcher on the next request. **Implication:** repeated requests for a non-existent slug each hit Supabase. Acceptable for MVP — non-existent slugs are rare and existing IP rate limiting on other public endpoints absorbs most abuse. Negative caching is deferred to a future change to `cacheGet` if it becomes a problem. |
 | Fetcher throws | Lock is released in the `finally` block. No cache entry written. Next request retries. |
 
 ## Tradeoffs
 
 1. **Up to 5 minutes of staleness** after an owner edits branding or rewards. Mitigation: TTL is configurable in one place (`CacheTTL`). If owners complain, lower to 60 seconds (the DB savings still apply at 1-minute TTL for high-traffic shops). If they complain again, upgrade to active invalidation (see Future Work).
-2. **`null` is cached for the same TTL as a real value.** A typo'd URL won't DoS the DB, but a newly created business is invisible until the cached miss expires. Accepted for MVP.
+2. **`null` results are not cached.** Repeated 404 lookups for the same slug each hit Supabase. This is a property of the existing `cacheGet` helper, not the endpoint changes. Adding negative caching would require modifying `cacheGet` to use a sentinel or a separate "miss" marker; deferred to a future PR if needed.
 3. **No metrics on cache hit rate yet.** Sentry only catches errors. If we want to tune TTL based on real hit rates, add a metric later. Not in scope.
 
 ## Scalability Sanity Check (against `CLAUDE.md` rules)
@@ -158,7 +158,7 @@ No test framework is configured in the project (per `CLAUDE.md`), so verificatio
 3. **TTL expiry.** Wait 5+ minutes, hit again, confirm a fresh Supabase query happens (check Supabase logs or just observe timing).
 4. **No Redis configured.** Temporarily unset `UPSTASH_REDIS_REST_URL` in the local env, restart dev server, hit endpoints, confirm they still work and return correct data.
 5. **Stale-data check.** Edit a logo in the dashboard. Confirm customer side shows new logo within 5 minutes (or immediately after manually deleting the cache key from Upstash).
-6. **404 caching.** Hit `/api/public/business/<nonexistent-slug>`. Confirm 404. Hit again — confirm Upstash shows the key with a `null` value and the second request is fast.
+6. **404 behavior.** Hit `/api/public/business/<nonexistent-slug>`. Confirm 404. Hit again — confirm 404 still returns and that `cacheGet` does NOT store the `null` in Upstash (no `business:slug:<nonexistent-slug>` key appears). Both requests touch Supabase; this is the documented non-caching of negatives.
 7. **Lint + typecheck.** `npm run lint` and `npm run typecheck` from `apps/web` pass with no new errors (per project pre-commit rule).
 
 ## Future Work (out of scope for this PR)

--- a/docs/superpowers/specs/2026-05-19-cache-public-business-endpoints-design.md
+++ b/docs/superpowers/specs/2026-05-19-cache-public-business-endpoints-design.md
@@ -1,0 +1,169 @@
+# Cache Public Business Endpoints — Design
+
+**Date:** 2026-05-19
+**Status:** Draft, pending implementation
+**Branch:** `feat/cache-public-business-endpoints`
+
+## Problem
+
+Two public read endpoints are hit on every customer QR scan and every customer-facing page load:
+
+- `GET /api/public/business/[slug]` — returns business profile (name, logo, branding, loyalty mode, stamp template)
+- `GET /api/public/business/[slug]/rewards` — returns the active rewards catalog
+
+Each request currently performs a fresh Supabase round-trip (1–2 queries for the business endpoint, 1 query for the rewards endpoint). Under realistic traffic — e.g. a busy shop with hundreds of customers scanning per hour — this is wasted DB load and connection-pool consumption for data that changes infrequently (owners edit branding and rewards on the order of days or weeks, not seconds).
+
+A Redis-backed cache helper already exists in `apps/web/lib/cache.ts` with stampede protection, but no endpoint currently calls it. This design wires the helper into the two endpoints above.
+
+## Goals
+
+- Reduce Supabase load on the two highest-traffic public read endpoints.
+- Use the existing `cacheGet` helper and Upstash Redis client — no new infrastructure.
+- Preserve current behavior when Redis is not configured (graceful no-op).
+- Keep changes scoped to two route files and the cache key registry (small blast radius, low merge-conflict risk).
+
+## Non-goals
+
+- Caching the PIN-authenticated lookup endpoint (`/api/public/business/[slug]/lookup`) — it returns customer-specific data and writes to the DB on every call.
+- Caching customer points, stamp progress, or transactions — these change in real time during stamping/redemption.
+- Active cache invalidation triggered from dashboard write paths — dashboard pages write directly to Supabase from the browser today, so there is no server-side mutation hook to call. Invalidation is deferred to TTL expiry; see Tradeoffs.
+- Adding rate limiting to the GET endpoints — separate concern, separate PR.
+- Refactoring dashboard pages to use API routes for writes — out of scope.
+
+## Approach: TTL-Only Cache-Aside
+
+Wrap the existing service-function calls in the two routes with `cacheGet(key, fetcher, { ttlSeconds: 300 })`. On a hit, return the cached value in ~5ms. On a miss, fetch from Supabase, store with a 5-minute TTL, return.
+
+Owners see edits propagate to the customer side within at most 5 minutes. For logo/branding/rewards catalog, this delay is invisible to users.
+
+## Changes
+
+### File: `apps/web/lib/cache.ts`
+
+Add a key + TTL for the business profile alongside the existing rewards entries.
+
+```ts
+export const CacheKeys = {
+  business: (slug: string) => `business:slug:${slug}`,
+  rewards: (businessId: string) => `rewards:${businessId}`,
+  points: (customerId: string) => `points:${customerId}`,
+  leaderboard: (businessId: string) => `leaderboard:${businessId}`,
+};
+
+export const CacheTTL = {
+  business: 300,     // 5 minutes
+  rewards: 300,      // 5 minutes (already exists)
+  points: 10,
+  leaderboard: 60,
+};
+```
+
+### File: `apps/web/app/api/public/business/[slug]/route.ts`
+
+Wrap the `getBusinessBySlug` call with `cacheGet`.
+
+```ts
+import { cacheGet, CacheKeys, CacheTTL } from '@/lib/cache';
+
+// inside GET:
+const business = await cacheGet(
+  CacheKeys.business(slug),
+  () => getBusinessBySlug(slug),
+  { ttlSeconds: CacheTTL.business }
+);
+```
+
+### File: `apps/web/app/api/public/business/[slug]/rewards/route.ts`
+
+The business lookup at the top of this handler also benefits from caching. Reuse the same `business` key, then cache rewards by business ID.
+
+```ts
+import { cacheGet, CacheKeys, CacheTTL } from '@/lib/cache';
+
+// inside GET:
+const business = await cacheGet(
+  CacheKeys.business(slug),
+  () => getBusinessBySlug(slug),
+  { ttlSeconds: CacheTTL.business }
+);
+
+if (!business) {
+  return NextResponse.json(
+    { success: false, error: 'Business not found' },
+    { status: 404 }
+  );
+}
+
+const rewards = await cacheGet(
+  CacheKeys.rewards(business.id),
+  () => getPublicRewards(business.id),
+  { ttlSeconds: CacheTTL.rewards }
+);
+```
+
+## Data Flow
+
+**Cache hit (steady state):**
+
+1. Request arrives at the route handler.
+2. `cacheGet` calls `redis.get(key)` → returns cached value in ~5ms.
+3. Route returns JSON response. No DB query.
+
+**Cache miss (first request or after TTL expiry):**
+
+1. `cacheGet` calls `redis.get(key)` → returns `null`.
+2. `cacheGet` acquires a `SET NX` lock (`lock:<key>`, 10s expiry).
+3. Fetcher runs (`getBusinessBySlug` or `getPublicRewards`) → Supabase query.
+4. Result stored in Redis with TTL 300s.
+5. Lock released. Response returned.
+
+**Stampede (cold cache, many concurrent requests):**
+
+1. First request acquires lock, fetches, populates cache.
+2. Concurrent requests fail to acquire the lock, wait 200ms, retry cache read.
+3. After the populator finishes, retried requests hit the now-warm cache.
+4. If a retry is still a miss (rare — populator crashed), it falls through to a direct fetch without locking.
+
+This is already implemented in `cacheGet`. No new code needed.
+
+## Error Handling
+
+| Scenario | Behavior |
+|---|---|
+| `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` env vars missing | `getRedis()` returns `null` → `cacheGet` calls the fetcher directly. Endpoints work normally with no caching. |
+| Redis is configured but errors mid-request (network blip, Upstash outage) | Exception propagates out of `cacheGet` and is caught by the route's existing `try/catch`, which returns a 500. Sentry captures the error. **Acceptable** — Redis outages are rare, and we want visibility, not silent fallback. |
+| Fetcher (Supabase) returns `null` (business not found) | `null` is stored in Redis with the same TTL. Subsequent requests for the same slug return 404 without hitting the DB. Prevents a typo'd slug from DoS-ing the DB. **Tradeoff:** if a real business is created with that slug within 5 minutes, customers see 404 until the cached `null` expires. Accepted — slug creation is rare. |
+| Fetcher throws | Lock is released in the `finally` block. No cache entry written. Next request retries. |
+
+## Tradeoffs
+
+1. **Up to 5 minutes of staleness** after an owner edits branding or rewards. Mitigation: TTL is configurable in one place (`CacheTTL`). If owners complain, lower to 60 seconds (the DB savings still apply at 1-minute TTL for high-traffic shops). If they complain again, upgrade to active invalidation (see Future Work).
+2. **`null` is cached for the same TTL as a real value.** A typo'd URL won't DoS the DB, but a newly created business is invisible until the cached miss expires. Accepted for MVP.
+3. **No metrics on cache hit rate yet.** Sentry only catches errors. If we want to tune TTL based on real hit rates, add a metric later. Not in scope.
+
+## Scalability Sanity Check (against `CLAUDE.md` rules)
+
+- No new realtime channels.
+- No new unbounded queries; no new in-memory filtering.
+- No new sequential awaits in a loop.
+- Relies on existing indexes (`businesses.slug`, `rewards.business_id`).
+- Reduces DB load and connection-pool consumption on the two hottest public endpoints. Direct contribution to the connection-budget headroom called out in `CLAUDE.md`.
+
+## Testing
+
+No test framework is configured in the project (per `CLAUDE.md`), so verification is manual.
+
+1. **Cold cache → warm cache.** Hit `/api/public/business/<known-slug>` twice from the browser. Second response is noticeably faster. Confirm the `business:slug:<slug>` key appears in the Upstash dashboard.
+2. **Rewards endpoint.** Hit `/api/public/business/<known-slug>/rewards` twice. Confirm both `business:slug:<slug>` and `rewards:<id>` keys appear in Upstash.
+3. **TTL expiry.** Wait 5+ minutes, hit again, confirm a fresh Supabase query happens (check Supabase logs or just observe timing).
+4. **No Redis configured.** Temporarily unset `UPSTASH_REDIS_REST_URL` in the local env, restart dev server, hit endpoints, confirm they still work and return correct data.
+5. **Stale-data check.** Edit a logo in the dashboard. Confirm customer side shows new logo within 5 minutes (or immediately after manually deleting the cache key from Upstash).
+6. **404 caching.** Hit `/api/public/business/<nonexistent-slug>`. Confirm 404. Hit again — confirm Upstash shows the key with a `null` value and the second request is fast.
+7. **Lint + typecheck.** `npm run lint` and `npm run typecheck` from `apps/web` pass with no new errors (per project pre-commit rule).
+
+## Future Work (out of scope for this PR)
+
+- Active invalidation: when an owner edits rewards or branding, immediately invalidate the relevant cache keys. Requires either moving dashboard writes to API routes, adding a small invalidation endpoint the dashboard calls after edits, or wiring a Supabase Database Webhook.
+- Cache hit-rate metrics: send hit/miss counters to a metrics backend so TTLs can be tuned based on real traffic patterns.
+- Cache the `/api/public/referral/validate` endpoint and the public business directory listing, once this pattern is proven.
+- Add rate limiting to the cached GET endpoints (currently unrated, easy DoS target even with caching).


### PR DESCRIPTION
## Summary
- Wire existing `cacheGet` helper into `GET /api/public/business/[slug]` and `GET /api/public/business/[slug]/rewards`
- Add `CacheKeys.business(slug)` and `CacheTTL.business = 300` to `apps/web/lib/cache.ts`
- TTL-only (5 min). No active invalidation in this PR — dashboards write directly to Supabase from the browser today, so there's no server-side mutation hook to call.

## Spec / plan
- Spec: `docs/superpowers/specs/2026-05-19-cache-public-business-endpoints-design.md`
- Plan: `docs/superpowers/plans/2026-05-19-cache-public-business-endpoints.md`

## Why
These two endpoints are hit on every customer QR scan and every customer-facing page load. Business profile and rewards catalog change on the order of days. Caching for 5 minutes eliminates the vast majority of DB queries during traffic spikes and frees up Supabase connection-pool headroom.

## Behavior notes worth a second look
- **404s are NOT cached.** `cacheGet`'s hit-check excludes `null`, so repeated requests for a nonexistent slug each hit Supabase. Documented as a known limitation in the spec; negative caching deferred to a future PR if needed.
- **Redis errors during a request surface as a 500.** Intentional (we want Sentry visibility on Upstash issues, not silent fallback). On-call should be aware.
- **No-Redis fallback works.** If `UPSTASH_REDIS_REST_URL` / `_TOKEN` are unset, `getRedis()` returns `null` and `cacheGet` calls the fetcher directly — endpoints behave exactly as before.

## Out of scope
- Active invalidation from dashboard write paths (would require moving dashboard writes to API routes or adding a Supabase Database Webhook)
- Caching the PIN-auth `lookup` endpoint (per-customer, security-sensitive)
- Rate limiting on the GET endpoints (separate concern, separate PR)

## Test plan
- [ ] Hit each cached endpoint twice from the browser/curl; second call is noticeably faster
- [ ] Confirm `business:slug:<slug>` and `rewards:<id>` keys appear in Upstash dashboard with ~300s TTL
- [ ] Confirm endpoints still return correct data when Redis env vars are unset (graceful no-op)
- [ ] Confirm a 404 for a nonexistent slug does NOT create a cache key (negative-cache exclusion)
- [ ] Confirm dashboard edits propagate to customer side within 5 minutes